### PR TITLE
Smart Tab indentation and Default Indentation preference

### DIFF
--- a/Moped/EditorState.swift
+++ b/Moped/EditorState.swift
@@ -194,6 +194,7 @@ final class EditorState: NSObject, ObservableObject {
 	}
 
 	private func applyPreferences() {
+		textView?.invalidateIndentStyleCache()
 		currentFontSize = preferences.fontSizeFloat
 		if !highlightingEnabled {
 			setLineWrap(to: preferences.doLineWrap)
@@ -390,6 +391,10 @@ final class MopedTextView: NSTextView {
 		cachedIndentStyle = nil
 	}
 
+	func invalidateIndentStyleCache() {
+		cachedIndentStyle = nil
+	}
+
 	override func insertTab(_ sender: Any?) {
 		let selectedRange = selectedRange()
 		if selectedRange.length > 0 {
@@ -568,7 +573,7 @@ final class MopedTextView: NSTextView {
 		let spaceIndentedLineCount = spaceIndentCounts.values.reduce(0, +)
 		let style: IndentStyle
 		if tabIndentedLineCount == 0, spaceIndentedLineCount == 0 {
-			switch Preferences.userShared.selectedDefaultIndentation {
+			switch editorState?.preferences.selectedDefaultIndentation ?? .tab {
 			case .tab:        style = .hardTab
 			case .twoSpaces:  style = .softSpaces(2)
 			case .fourSpaces: style = .softSpaces(4)

--- a/Moped/EditorState.swift
+++ b/Moped/EditorState.swift
@@ -390,6 +390,28 @@ final class MopedTextView: NSTextView {
 		cachedIndentStyle = nil
 	}
 
+	override func insertTab(_ sender: Any?) {
+		let selectedRange = selectedRange()
+		if selectedRange.length > 0 {
+			_ = adjustIndentation(true)
+			return
+		}
+
+		let style = detectIndentStyle(in: string)
+		switch style {
+		case .hardTab:
+			super.insertTab(sender)
+		case .softSpaces(let width):
+			let text = string as NSString
+			let searchRange = NSRange(location: 0, length: selectedRange.location)
+			let previousNewline = text.range(of: "\n", options: .backwards, range: searchRange)
+			let lineStart = previousNewline.location == NSNotFound ? 0 : previousNewline.location + 1
+			let column = selectedRange.location - lineStart
+			let spacesToInsert = width - (column % width)
+			insertText(String(repeating: " ", count: spacesToInsert), replacementRange: selectedRange)
+		}
+	}
+
 	override func performKeyEquivalent(with event: NSEvent) -> Bool {
 		let modifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
 		guard modifiers == .command,
@@ -546,7 +568,11 @@ final class MopedTextView: NSTextView {
 		let spaceIndentedLineCount = spaceIndentCounts.values.reduce(0, +)
 		let style: IndentStyle
 		if tabIndentedLineCount == 0, spaceIndentedLineCount == 0 {
-			style = .hardTab
+			switch Preferences.userShared.selectedDefaultIndentation {
+			case .tab:        style = .hardTab
+			case .twoSpaces:  style = .softSpaces(2)
+			case .fourSpaces: style = .softSpaces(4)
+			}
 		} else if tabIndentedLineCount > spaceIndentedLineCount {
 			style = .hardTab
 		} else {

--- a/Moped/Localizable.xcstrings
+++ b/Moped/Localizable.xcstrings
@@ -4902,6 +4902,16 @@
         }
       }
     },
+    "pref.default_indentation.title" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Default Indent:"
+          }
+        }
+      }
+    },
     "pref.line_numbers.title" : {
       "extractionState" : "stale",
       "localizations" : {

--- a/Moped/Localizable.xcstrings
+++ b/Moped/Localizable.xcstrings
@@ -3990,6 +3990,36 @@
         }
       }
     },
+    "option.indent.four_spaces" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "4 Spaces"
+          }
+        }
+      }
+    },
+    "option.indent.tab" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tab"
+          }
+        }
+      }
+    },
+    "option.indent.two_spaces" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2 Spaces"
+          }
+        }
+      }
+    },
     "option.empty_editor" : {
       "extractionState" : "stale",
       "localizations" : {

--- a/Moped/Localizable.xcstrings
+++ b/Moped/Localizable.xcstrings
@@ -3992,30 +3992,246 @@
     },
     "option.indent.four_spaces" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "4 Leerzeichen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "4 Spaces"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "4 espacios"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "4 välilyöntiä"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "4 espaces"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "4 רווחים"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "4 रिक्त स्थान"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "4 spazi"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スペース4つ"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "4 spaties"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "4 espaços"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "4 espaços"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "4 пробіли"
           }
         }
       }
     },
     "option.indent.tab" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tabulator"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tab"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tabulación"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sarkainkohta"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tabulation"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "טאב"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "टैब"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tabulazione"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タブ"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tab"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tab"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tab"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Табуляція"
           }
         }
       }
     },
     "option.indent.two_spaces" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2 Leerzeichen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "2 Spaces"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2 espacios"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2 välilyöntiä"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2 espaces"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2 רווחים"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2 रिक्त स्थान"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2 spazi"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スペース2つ"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2 spaties"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2 espaços"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2 espaços"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2 пробіли"
           }
         }
       }
@@ -4934,10 +5150,82 @@
     },
     "pref.default_indentation.title" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Standardeinzug:"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Default Indent:"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sangría predeterminada:"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oletussisentäminen:"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Indentation par défaut :"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "כניסה ברירת מחדל:"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "डिफ़ॉल्ट इंडेंट:"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rientro predefinito:"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "デフォルトのインデント:"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Standaard inspringing:"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Indentação padrão:"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Indentação padrão:"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Відступ за замовчуванням:"
           }
         }
       }

--- a/Moped/Preferences.swift
+++ b/Moped/Preferences.swift
@@ -23,17 +23,9 @@ import Foundation
 
 class Preferences: NSObject, ObservableObject {
 	enum DefaultIndentation: String, CaseIterable {
-		case tab = "Tab"
-		case twoSpaces = "2 Spaces"
-		case fourSpaces = "4 Spaces"
-
-		var indentStyle: (isTab: Bool, width: Int) {
-			switch self {
-			case .tab:        return (true, 1)
-			case .twoSpaces:  return (false, 2)
-			case .fourSpaces: return (false, 4)
-			}
-		}
+		case tab = "tab"
+		case twoSpaces = "twoSpaces"
+		case fourSpaces = "fourSpaces"
 	}
 
 	enum AppIcon: String, CaseIterable {
@@ -73,10 +65,16 @@ class Preferences: NSObject, ObservableObject {
 
 	@objc dynamic var defaultIndentation: String {
 		get {
-			getStringValue(forKey: "defaultIndentation", otherwiseUse: DefaultIndentation.tab.rawValue)
+			let stored = getStringValue(
+				forKey: "defaultIndentation",
+				otherwiseUse: DefaultIndentation.tab.rawValue
+			)
+			return DefaultIndentation(rawValue: stored)?.rawValue ?? DefaultIndentation.tab.rawValue
 		}
 		set {
-			setStringValue(forKey: "defaultIndentation", to: newValue)
+			let validated = DefaultIndentation(rawValue: newValue)?.rawValue
+				?? DefaultIndentation.tab.rawValue
+			setStringValue(forKey: "defaultIndentation", to: validated)
 		}
 	}
 

--- a/Moped/Preferences.swift
+++ b/Moped/Preferences.swift
@@ -22,6 +22,20 @@ import Combine
 import Foundation
 
 class Preferences: NSObject, ObservableObject {
+	enum DefaultIndentation: String, CaseIterable {
+		case tab = "Tab"
+		case twoSpaces = "2 Spaces"
+		case fourSpaces = "4 Spaces"
+
+		var indentStyle: (isTab: Bool, width: Int) {
+			switch self {
+			case .tab:        return (true, 1)
+			case .twoSpaces:  return (false, 2)
+			case .fourSpaces: return (false, 4)
+			}
+		}
+	}
+
 	enum AppIcon: String, CaseIterable {
 		case defaultIcon = "Default"
 		case pink = "Pink"
@@ -56,6 +70,19 @@ class Preferences: NSObject, ObservableObject {
 	}()
 
 	// MARK: - Preferences / Properties
+
+	@objc dynamic var defaultIndentation: String {
+		get {
+			getStringValue(forKey: "defaultIndentation", otherwiseUse: DefaultIndentation.tab.rawValue)
+		}
+		set {
+			setStringValue(forKey: "defaultIndentation", to: newValue)
+		}
+	}
+
+	var selectedDefaultIndentation: DefaultIndentation {
+		DefaultIndentation(rawValue: defaultIndentation) ?? .tab
+	}
 
 	@objc dynamic var language: String {
 		get {

--- a/Moped/PreferencesView.swift
+++ b/Moped/PreferencesView.swift
@@ -59,9 +59,11 @@ struct PreferencesView: View {
 			PreferenceOption(value: "FileOpenDialog", label: String(localized: "option.file_open_dialog")),
 			PreferenceOption(value: "EmptyEditor", label: String(localized: "option.empty_editor"))
 		]
-		defaultIndentationOptions = Preferences.DefaultIndentation.allCases.map {
-			PreferenceOption(value: $0.rawValue, label: $0.rawValue)
-		}
+		defaultIndentationOptions = [
+			PreferenceOption(value: Preferences.DefaultIndentation.tab.rawValue, label: String(localized: "option.indent.tab")),
+			PreferenceOption(value: Preferences.DefaultIndentation.twoSpaces.rawValue, label: String(localized: "option.indent.two_spaces")),
+			PreferenceOption(value: Preferences.DefaultIndentation.fourSpaces.rawValue, label: String(localized: "option.indent.four_spaces"))
+		]
 	}
 
 	var body: some View {

--- a/Moped/PreferencesView.swift
+++ b/Moped/PreferencesView.swift
@@ -36,6 +36,7 @@ struct PreferencesView: View {
 	private let wrapOptions: [PreferenceOption]
 	private let lineNumberRulerOptions: [PreferenceOption]
 	private let launchBehaviorOptions: [PreferenceOption]
+	private let defaultIndentationOptions: [PreferenceOption]
 	private let appIconOptions = Preferences.AppIcon.allCases.map { $0.rawValue }
 
 	init(preferences: Preferences) {
@@ -58,6 +59,9 @@ struct PreferencesView: View {
 			PreferenceOption(value: "FileOpenDialog", label: String(localized: "option.file_open_dialog")),
 			PreferenceOption(value: "EmptyEditor", label: String(localized: "option.empty_editor"))
 		]
+		defaultIndentationOptions = Preferences.DefaultIndentation.allCases.map {
+			PreferenceOption(value: $0.rawValue, label: $0.rawValue)
+		}
 	}
 
 	var body: some View {
@@ -126,6 +130,15 @@ struct PreferencesView: View {
 			)
 
 			PreferenceRow(
+				title: "pref.default_indentation.title",
+				selection: Binding(
+					get: { preferences.defaultIndentation },
+					set: { preferences.defaultIndentation = $0 }
+				),
+				options: defaultIndentationOptions
+			)
+
+			PreferenceRow(
 				title: "pref.active_icon.title",
 				selection: Binding(
 					get: { preferences.appIcon },
@@ -145,7 +158,7 @@ struct PreferencesView: View {
 			}
 		}
 		.padding(20)
-		.frame(width: 430, height: 380, alignment: .topLeading)
+		.frame(width: 430, height: 410, alignment: .topLeading)
 	}
 }
 


### PR DESCRIPTION
## Summary

- **Smart Tab key**: The Tab key now inserts the file's detected indent unit rather than always inserting a raw tab character. For space-indented files it inserts spaces aligned to the next tab stop (e.g. hitting Tab at column 3 in a 4-space file inserts 1 space to reach column 4). For tab-indented files it falls through to the system default. With a selection, Tab indents all selected lines — same as Cmd+].
- **Default Indentation preference**: Added a new `DefaultIndentation` preference (Tab / 2 Spaces / 4 Spaces) that controls the indent style used when a file has no detectable indentation (new files, single-line scripts, empty files, etc.). Auto-detection continues to take precedence for files that already have a clear indent style.
- **Preference UI**: New row added to Preferences window between "On Launch" and "App Icon". Frame height bumped to accommodate the extra row.
- **Localization**: Added `pref.default_indentation.title` key in English; other locales can be translated in a follow-up.

## Files changed

| File | What changed |
|---|---|
| `Moped/EditorState.swift` | `insertTab` override in `MopedTextView`; `detectIndentStyle` fallback reads preference |
| `Moped/Preferences.swift` | `DefaultIndentation` enum, `defaultIndentation` UserDefaults property, `selectedDefaultIndentation` accessor |
| `Moped/PreferencesView.swift` | New `PreferenceRow` for default indentation, frame height 380→410 |
| `Moped/Localizable.xcstrings` | `pref.default_indentation.title` key (English) |

## Test plan

- [ ] Open a space-indented file (e.g. any `.swift` in the project) — Tab key at various column positions should insert the correct number of spaces to reach the next 4-space tab stop
- [ ] Open a tab-indented file — Tab key should insert a tab character as before
- [ ] Open Preferences, confirm "Default Indent:" row appears between "On Launch" and "App Icon"
- [ ] Set Default Indent to "2 Spaces", open a new empty file, type some code and hit Return — new lines should be space-indented; Tab should insert 2 spaces
- [ ] Set Default Indent to "4 Spaces", repeat above
- [ ] Set Default Indent to "Tab", confirm tab-character behavior on new files
- [ ] Cmd+] / Cmd+[ still work correctly for block indent/outdent on all styles

🤖 Generated with [Claude Code](https://claude.com/claude-code)