### PR TITLE
Redesign the Settings window, add a System theme, fix launch behavior

### DIFF
--- a/Moped/AppDelegate.swift
+++ b/Moped/AppDelegate.swift
@@ -28,19 +28,44 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
 	// MARK: - Application Delegate
 
+	/// Applies the "On Launch" preference, but only when nothing else is already on its
+	/// way in.
+	///
+	/// The signal is `NSApplication.launchIsDefaultUserInfoKey`, which Launch Services
+	/// sets to `false` when the app was launched *to open something* — a Finder
+	/// double-click or `moped <file>` — and `true` for a plain launch. It is known up
+	/// front, which is what makes it usable here.
+	///
+	/// This replaces a `NSDocumentController.shared.documents.isEmpty` guard that was a
+	/// race rather than a check. `kAEOpenDocuments` is delivered asynchronously and
+	/// `MopedDocument.init(configuration:)` is nonisolated so SwiftUI builds documents
+	/// off the main thread; the guard, running on the main actor, could see an empty
+	/// array while the CLI's file was still being read, and drop an untitled window on
+	/// top of the file the user actually asked for.
+	///
+	/// The work has to happen here rather than in `applicationOpenUntitledFile(_:)`:
+	/// SwiftUI's `DocumentGroup` never consults that hook (verified — neither it nor
+	/// `applicationShouldOpenUntitledFile(_:)` is called), and it presents its own open
+	/// panel shortly after this returns. Acting now is what preempts that panel; the
+	/// "File Open Dialog" case simply declines to act and lets it appear.
 	func applicationDidFinishLaunching(_ aNotification: Notification) {
 		NSApp.setActivationPolicy(.regular)
 		NSApp.activate(ignoringOtherApps: true)
 		applySelectedAppIcon()
 		startObservingPreferenceChanges()
 
-		// Skip launch behavior if documents were already opened externally
-		// (e.g., via Finder double-click or `moped <file>` from the CLI).
-		guard NSDocumentController.shared.documents.isEmpty else { return }
+		let isPlainLaunch = aNotification
+			.userInfo?[NSApplication.launchIsDefaultUserInfoKey] as? Bool ?? true
+		guard isPlainLaunch else {
+			return
+		}
 
 		let prefs = Preferences.userShared
 		if prefs.reopenPreviousOnLaunch {
-			reopenPreviousDocuments()
+			// An exhausted or fully stale session falls back to an empty editor.
+			if !reopenPreviousDocuments() {
+				NSDocumentController.shared.newDocument(nil)
+			}
 		} else if prefs.openEmptyOnLaunch {
 			NSDocumentController.shared.newDocument(nil)
 		}
@@ -99,10 +124,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 		Preferences.userShared.lastOpenDocuments = entries
 	}
 
-	private func reopenPreviousDocuments() {
+	/// Returns whether at least one bookmark resolved and an open was dispatched, so the
+	/// caller can fall back to an empty editor when there is nothing left to restore.
+	private func reopenPreviousDocuments() -> Bool {
 		let entries = Preferences.userShared.lastOpenDocuments
 		var refreshedEntries: [RestoredDocument] = []
 		var refreshedAny = false
+		var openedAny = false
 
 		for entry in entries {
 			var isStale = false
@@ -133,6 +161,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 				refreshedEntries.append(entry)
 			}
 
+			openedAny = true
 			let savedFrame = entry.frame.map { NSRectFromString($0) }
 			NSDocumentController.shared.openDocument(
 				withContentsOf: url,
@@ -148,6 +177,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 		if refreshedAny {
 			Preferences.userShared.lastOpenDocuments = refreshedEntries
 		}
+		return openedAny
 	}
 
 	private func applyFrame(_ rect: NSRect, to document: NSDocument, retriesLeft: Int) {

--- a/Moped/Localizable.xcstrings
+++ b/Moped/Localizable.xcstrings
@@ -3161,6 +3161,90 @@
         }
       }
     },
+    "error.file_binary.description" : {
+      "comment" : "Alert text when the file is not text, on open or on reload.",
+      "extractionState" : "stale",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Moped kann nur Textdateien öffnen; diese Datei scheint binär zu sein."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Moped can only open text files, and this file appears to be binary."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Moped solo puede abrir archivos de texto y este archivo parece ser binario."
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Moped voi avata vain tekstitiedostoja, ja tämä tiedosto vaikuttaa binääriseltä."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Moped ne peut ouvrir que des fichiers texte, et ce fichier semble être binaire."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Moped יכול לפתוח קבצי טקסט בלבד, והקובץ הזה נראה בינארי."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Moped केवल टेक्स्ट फ़ाइलें खोल सकता है, और यह फ़ाइल बाइनरी प्रतीत होती है।"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Moped può aprire solo file di testo e questo file sembra essere binario."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mopedはテキストファイルのみ開けます。このファイルはバイナリのようです。"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Moped kan alleen tekstbestanden openen en dit bestand lijkt binair te zijn."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "O Moped só pode abrir ficheiros de texto e este ficheiro parece ser binário."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "O Moped só pode abrir arquivos de texto e este arquivo parece ser binário."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Moped може відкривати лише текстові файли, а цей файл виглядає двійковим."
+          }
+        }
+      }
+    },
     "error.file_too_large.recovery_format" : {
       "comment" : "Alert body. %1$@ is the size limit (e.g. \"4 MB\"); %2$@ is the file's actual size.",
       "extractionState" : "stale",
@@ -3325,90 +3409,6 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Moped не зміг визначити кодування тексту цього файлу."
-          }
-        }
-      }
-    },
-    "error.file_binary.description" : {
-      "comment" : "Alert text when the file is not text, on open or on reload.",
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Moped kann nur Textdateien öffnen; diese Datei scheint binär zu sein."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Moped can only open text files, and this file appears to be binary."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Moped solo puede abrir archivos de texto y este archivo parece ser binario."
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Moped voi avata vain tekstitiedostoja, ja tämä tiedosto vaikuttaa binääriseltä."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Moped ne peut ouvrir que des fichiers texte, et ce fichier semble être binaire."
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Moped יכול לפתוח קבצי טקסט בלבד, והקובץ הזה נראה בינארי."
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Moped केवल टेक्स्ट फ़ाइलें खोल सकता है, और यह फ़ाइल बाइनरी प्रतीत होती है।"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Moped può aprire solo file di testo e questo file sembra essere binario."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Mopedはテキストファイルのみ開けます。このファイルはバイナリのようです。"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Moped kan alleen tekstbestanden openen en dit bestand lijkt binair te zijn."
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "O Moped só pode abrir ficheiros de texto e este ficheiro parece ser binário."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "O Moped só pode abrir arquivos de texto e este arquivo parece ser binário."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Moped може відкривати лише текстові файли, а цей файл виглядає двійковим."
           }
         }
       }
@@ -4990,6 +4990,174 @@
         }
       }
     },
+    "option.icon.beige" : {
+      "comment" : "App icon choice in Preferences.",
+      "extractionState" : "stale",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Beige"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beige"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Beis"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Beige"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Beige"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "בז'"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "बेज"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Beige"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "ベージュ"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Beige"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Bege"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Bege"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Бежева"
+          }
+        }
+      }
+    },
+    "option.icon.black" : {
+      "comment" : "App icon choice in Preferences.",
+      "extractionState" : "stale",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Schwarz"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Black"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Negro"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Musta"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Noir"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "שחור"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "काला"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nera"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "ブラック"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Zwart"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Preto"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Preto"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Чорна"
+          }
+        }
+      }
+    },
     "option.icon.default" : {
       "comment" : "App icon choice in Preferences.",
       "extractionState" : "stale",
@@ -5158,174 +5326,6 @@
         }
       }
     },
-    "option.icon.black" : {
-      "comment" : "App icon choice in Preferences.",
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Schwarz"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Black"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Negro"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Musta"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Noir"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "שחור"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "काला"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Nera"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "ブラック"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Zwart"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Preto"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Preto"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Чорна"
-          }
-        }
-      }
-    },
-    "option.icon.red" : {
-      "comment" : "App icon choice in Preferences.",
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Rot"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Red"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Rojo"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Punainen"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Rouge"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "אדום"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "लाल"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Rossa"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "レッド"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Rood"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Vermelho"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Vermelho"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Червона"
-          }
-        }
-      }
-    },
     "option.icon.rainbow" : {
       "comment" : "App icon choice in Preferences.",
       "extractionState" : "stale",
@@ -5410,86 +5410,86 @@
         }
       }
     },
-    "option.icon.beige" : {
+    "option.icon.red" : {
       "comment" : "App icon choice in Preferences.",
       "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Beige"
+            "value" : "Rot"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Beige"
+            "value" : "Red"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Beis"
+            "value" : "Rojo"
           }
         },
         "fi" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Beige"
+            "value" : "Punainen"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Beige"
+            "value" : "Rouge"
           }
         },
         "he" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "בז'"
+            "value" : "אדום"
           }
         },
         "hi" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "बेज"
+            "value" : "लाल"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Beige"
+            "value" : "Rossa"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "ベージュ"
+            "value" : "レッド"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Beige"
+            "value" : "Rood"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Bege"
+            "value" : "Vermelho"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Bege"
+            "value" : "Vermelho"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Бежева"
+            "value" : "Червона"
           }
         }
       }
@@ -5909,90 +5909,6 @@
         }
       }
     },
-    "option.theme.default_light" : {
-      "comment" : "Editor theme choice in Preferences.",
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Standard Hell"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Default Light"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Claro predeterminado"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Vaalea oletus"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Clair par défaut"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "בהיר (ברירת מחדל)"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "डिफ़ॉल्ट लाइट"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Chiaro predefinito"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "デフォルト（ライト）"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Standaard licht"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Claro predefinido"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Claro padrão"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Стандартна світла"
-          }
-        }
-      }
-    },
     "option.theme.default_dark" : {
       "comment" : "Editor theme choice in Preferences.",
       "extractionState" : "stale",
@@ -6077,86 +5993,170 @@
         }
       }
     },
-    "option.theme.xcode_like" : {
+    "option.theme.default_light" : {
       "comment" : "Editor theme choice in Preferences.",
       "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Xcode-ähnlich"
+            "value" : "Standard Hell"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Xcode-like"
+            "value" : "Default Light"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Estilo Xcode"
+            "value" : "Claro predeterminado"
           }
         },
         "fi" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Xcode-tyylinen"
+            "value" : "Vaalea oletus"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Style Xcode"
+            "value" : "Clair par défaut"
           }
         },
         "he" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "בסגנון Xcode"
+            "value" : "בהיר (ברירת מחדל)"
           }
         },
         "hi" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Xcode जैसा"
+            "value" : "डिफ़ॉल्ट लाइट"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Stile Xcode"
+            "value" : "Chiaro predefinito"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Xcode風"
+            "value" : "デフォルト（ライト）"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Xcode-achtig"
+            "value" : "Standaard licht"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Estilo Xcode"
+            "value" : "Claro predefinido"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Estilo Xcode"
+            "value" : "Claro padrão"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "У стилі Xcode"
+            "value" : "Стандартна світла"
+          }
+        }
+      }
+    },
+    "option.theme.solarized_dark" : {
+      "comment" : "Editor theme choice in Preferences.",
+      "extractionState" : "stale",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Solarized Dunkel"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Solarized Dark"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Solarized oscuro"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Solarized tumma"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Solarized sombre"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Solarized כהה"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Solarized डार्क"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Solarized scuro"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Solarized ダーク"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Solarized donker"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Solarized escuro"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Solarized escuro"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Solarized темна"
           }
         }
       }
@@ -6245,86 +6245,170 @@
         }
       }
     },
-    "option.theme.solarized_dark" : {
+    "option.theme.system" : {
+      "comment" : "Theme picker option that follows the system appearance instead of theming.",
+      "extractionState" : "stale",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "System"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "System"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sistema"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Järjestelmä"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Système"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "מערכת"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "सिस्टम"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sistema"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "システム"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Systeem"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sistema"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sistema"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Системна"
+          }
+        }
+      }
+    },
+    "option.theme.xcode_like" : {
       "comment" : "Editor theme choice in Preferences.",
       "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Solarized Dunkel"
+            "value" : "Xcode-ähnlich"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Solarized Dark"
+            "value" : "Xcode-like"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Solarized oscuro"
+            "value" : "Estilo Xcode"
           }
         },
         "fi" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Solarized tumma"
+            "value" : "Xcode-tyylinen"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Solarized sombre"
+            "value" : "Style Xcode"
           }
         },
         "he" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Solarized כהה"
+            "value" : "בסגנון Xcode"
           }
         },
         "hi" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Solarized डार्क"
+            "value" : "Xcode जैसा"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Solarized scuro"
+            "value" : "Stile Xcode"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Solarized ダーク"
+            "value" : "Xcode風"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Solarized donker"
+            "value" : "Xcode-achtig"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Solarized escuro"
+            "value" : "Estilo Xcode"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Solarized escuro"
+            "value" : "Estilo Xcode"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Solarized темна"
+            "value" : "У стилі Xcode"
           }
         }
       }
@@ -6418,79 +6502,79 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Aktives Symbol:"
+            "value" : "App-Symbol"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Active Icon:"
+            "value" : "App icon"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Icono activo:"
+            "value" : "Icono de la app"
           }
         },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Aktiivinen kuvake:"
+            "value" : "Apin kuvake"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Icône active :"
+            "value" : "Icône de l’app"
           }
         },
         "he" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "סמל פעיל:"
+            "value" : "סמל היישום"
           }
         },
         "hi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "सक्रिय आइकन:"
+            "value" : "ऐप आइकन"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Icona attiva:"
+            "value" : "Icona dell’app"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "アクティブアイコン:"
+            "value" : "Appアイコン"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Actief icoon:"
+            "value" : "App-icoon"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ícone ativo:"
+            "value" : "Ícone da app"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ícone ativo:"
+            "value" : "Ícone do app"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Активна іконка:"
+            "value" : "Іконка програми"
           }
         }
       }
@@ -6501,161 +6585,162 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Zuordnungen verwalten…"
+            "value" : "Verwalten…"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Manage Defaults…"
+            "value" : "Manage…"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Gestionar predeterminados…"
+            "value" : "Gestionar…"
           }
         },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Hallitse oletuksia…"
+            "value" : "Hallitse…"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Gérer les associations…"
+            "value" : "Gérer…"
           }
         },
         "he" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "נהל ברירות מחדל…"
+            "value" : "נהל…"
           }
         },
         "hi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "डिफ़ॉल्ट प्रबंधित करें…"
+            "value" : "प्रबंधित करें…"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Gestisci predefiniti…"
+            "value" : "Gestisci…"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "デフォルトを管理…"
+            "value" : "管理…"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Koppelingen beheren…"
+            "value" : "Beheren…"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Gerir predefinições…"
+            "value" : "Gerir…"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Gerenciar padrões…"
+            "value" : "Gerenciar…"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Керувати асоціаціями…"
+            "value" : "Керувати…"
           }
         }
       }
     },
     "pref.default_editor.title" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Standardeditor:"
+            "value" : "Dateizuordnungen"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Default Editor:"
+            "value" : "File associations"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Editor predeterminado:"
+            "value" : "Asociaciones de archivos"
           }
         },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Oletuseditori:"
+            "value" : "Tiedostoliitokset"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Éditeur par défaut :"
+            "value" : "Associations de fichiers"
           }
         },
         "he" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "עורך ברירת מחדל:"
+            "value" : "שיוכי קבצים"
           }
         },
         "hi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "डिफ़ॉल्ट एडिटर:"
+            "value" : "फ़ाइल संबद्धताएँ"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Editor predefinito:"
+            "value" : "Associazioni file"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "デフォルトエディタ:"
+            "value" : "ファイルの関連付け"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Standaardeditor:"
+            "value" : "Bestandskoppelingen"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Editor predefinido:"
+            "value" : "Associações de ficheiros"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Editor padrão:"
+            "value" : "Associações de arquivos"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Редактор за замовчуванням:"
+            "value" : "Асоціації файлів"
           }
         }
       }
@@ -6666,79 +6751,79 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Standardeinzug:"
+            "value" : "Einzug"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Default Indent:"
+            "value" : "Indentation"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sangría predeterminada:"
+            "value" : "Sangría"
           }
         },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Oletussisentäminen:"
+            "value" : "Sisennys"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Indentation par défaut :"
+            "value" : "Indentation"
           }
         },
         "he" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "כניסה ברירת מחדל:"
+            "value" : "כניסה"
           }
         },
         "hi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "डिफ़ॉल्ट इंडेंट:"
+            "value" : "इंडेंटेशन"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Rientro predefinito:"
+            "value" : "Rientro"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "デフォルトのインデント:"
+            "value" : "インデント"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Standaard inspringing:"
+            "value" : "Inspringing"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Indentação padrão:"
+            "value" : "Indentação"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Indentação padrão:"
+            "value" : "Indentação"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Відступ за замовчуванням:"
+            "value" : "Відступ"
           }
         }
       }
@@ -6749,79 +6834,79 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Schriftgröße:"
+            "value" : "Schriftgröße"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Font Size:"
+            "value" : "Font size"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tamaño de fuente:"
+            "value" : "Tamaño de fuente"
           }
         },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Kirjasinkoko:"
+            "value" : "Kirjasinkoko"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Taille de police :"
+            "value" : "Taille de police"
           }
         },
         "he" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "גודל גופן:"
+            "value" : "גודל גופן"
           }
         },
         "hi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "फ़ॉन्ट आकार:"
+            "value" : "फ़ॉन्ट आकार"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Dimensione carattere:"
+            "value" : "Dimensione"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "フォントサイズ:"
+            "value" : "フォントサイズ"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Lettergrootte:"
+            "value" : "Lettergrootte"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tamanho do tipo de letra:"
+            "value" : "Tamanho da letra"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tamanho da fonte:"
+            "value" : "Tamanho da fonte"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Розмір шрифту:"
+            "value" : "Розмір шрифту"
           }
         }
       }
@@ -6832,79 +6917,79 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Schriftart:"
+            "value" : "Schriftart"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Font:"
+            "value" : "Font"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Fuente:"
+            "value" : "Fuente"
           }
         },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Kirjasin:"
+            "value" : "Kirjasin"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Police :"
+            "value" : "Police"
           }
         },
         "he" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "גופן:"
+            "value" : "גופן"
           }
         },
         "hi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "फ़ॉन्ट:"
+            "value" : "फ़ॉन्ट"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Carattere:"
+            "value" : "Carattere"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "フォント:"
+            "value" : "フォント"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Lettertype:"
+            "value" : "Lettertype"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tipo de letra:"
+            "value" : "Tipo de letra"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Fonte:"
+            "value" : "Fonte"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Шрифт:"
+            "value" : "Шрифт"
           }
         }
       }
@@ -6915,79 +7000,79 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sprache:"
+            "value" : "Syntaxsprache"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Language:"
+            "value" : "Syntax language"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Lenguaje:"
+            "value" : "Lenguaje de sintaxis"
           }
         },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Kieli:"
+            "value" : "Syntaksin kieli"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Langage :"
+            "value" : "Langage de syntaxe"
           }
         },
         "he" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "שפה:"
+            "value" : "שפת תחביר"
           }
         },
         "hi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "भाषा:"
+            "value" : "सिंटैक्स भाषा"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Lingua:"
+            "value" : "Linguaggio sintassi"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "言語:"
+            "value" : "構文言語"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Taal:"
+            "value" : "Syntaxistaal"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Idioma:"
+            "value" : "Linguagem de sintaxe"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Idioma:"
+            "value" : "Linguagem de sintaxe"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Мова:"
+            "value" : "Мова синтаксису"
           }
         }
       }
@@ -6998,79 +7083,79 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Beim Start:"
+            "value" : "Beim Start"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "On Launch:"
+            "value" : "At startup"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Al iniciar:"
+            "value" : "Al iniciar"
           }
         },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Käynnistyksessä:"
+            "value" : "Käynnistettäessä"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Au démarrage :"
+            "value" : "Au démarrage"
           }
         },
         "he" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "בעת הפעלה:"
+            "value" : "בעת ההפעלה"
           }
         },
         "hi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "लॉन्च पर:"
+            "value" : "प्रारंभ होने पर"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "All'avvio:"
+            "value" : "All'avvio"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "起動時:"
+            "value" : "起動時"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bij opstarten:"
+            "value" : "Bij het starten"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ao iniciar:"
+            "value" : "Ao iniciar"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ao iniciar:"
+            "value" : "Ao iniciar"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "При запуску:"
+            "value" : "При запуску"
           }
         }
       }
@@ -7081,79 +7166,499 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Zeilennummern:"
+            "value" : "Zeilennummern anzeigen"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Line Numbers:"
+            "value" : "Show line numbers"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Números de línea:"
+            "value" : "Mostrar números de línea"
           }
         },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Rivinumerot:"
+            "value" : "Näytä rivinumerot"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Numéros de ligne :"
+            "value" : "Afficher les numéros de ligne"
           }
         },
         "he" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "מספרי שורות:"
+            "value" : "הצג מספרי שורות"
           }
         },
         "hi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "पंक्ति संख्याएं:"
+            "value" : "पंक्ति संख्याएँ दिखाएँ"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Numeri di riga:"
+            "value" : "Mostra i numeri di riga"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "行番号:"
+            "value" : "行番号を表示"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Regelnummers:"
+            "value" : "Toon regelnummers"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Números de linha:"
+            "value" : "Mostrar números de linha"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Números de linha:"
+            "value" : "Mostrar números de linha"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Номери рядків:"
+            "value" : "Показувати номери рядків"
+          }
+        }
+      }
+    },
+    "pref.monospaced_only.title" : {
+      "comment" : "Checkbox that filters the font picker down to fixed-pitch faces.",
+      "extractionState" : "stale",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nur dicktengleiche Schriften"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show only monospaced fonts"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Solo monoespaciadas"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vain tasalevyiset"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chasse fixe uniquement"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "הצג רק גופנים ברוחב אחיד"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "केवल मोनोस्पेस फ़ॉन्ट"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Solo a spaziatura fissa"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "等幅フォントのみ表示"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alleen vaste breedte"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apenas monoespaçados"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apenas monoespaçadas"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Лише моноширинні"
+          }
+        }
+      }
+    },
+    "pref.section.advanced" : {
+      "comment" : "Settings sidebar section for file association options.",
+      "extractionState" : "stale",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erweitert"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Advanced"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Avanzado"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lisäasetukset"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Avancé"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "מתקדם"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "उन्नत"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Avanzate"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "詳細"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geavanceerd"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Avançado"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Avançado"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Додатково"
+          }
+        }
+      }
+    },
+    "pref.section.appearance" : {
+      "comment" : "Settings sidebar section for theme and font options.",
+      "extractionState" : "stale",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erscheinungsbild"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Appearance"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apariencia"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ulkoasu"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apparence"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "מראה"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "दिखावट"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aspetto"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外観"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Weergave"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aparência"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aparência"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вигляд"
+          }
+        }
+      }
+    },
+    "pref.section.editing" : {
+      "comment" : "Settings sidebar section for editor behavior options.",
+      "extractionState" : "stale",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bearbeiten"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Editing"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Edición"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Muokkaus"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Édition"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "עריכה"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "संपादन"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modifica"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "編集"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bewerken"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Edição"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Edição"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Редагування"
+          }
+        }
+      }
+    },
+    "pref.section.general" : {
+      "comment" : "Settings sidebar section for startup and app-wide options.",
+      "extractionState" : "stale",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Allgemein"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "General"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "General"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yleiset"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Général"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "כללי"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "सामान्य"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Generali"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一般"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Algemeen"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geral"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geral"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Загальні"
           }
         }
       }
@@ -7164,79 +7669,79 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Thema:"
+            "value" : "Thema"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Theme:"
+            "value" : "Theme"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tema:"
+            "value" : "Tema"
           }
         },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Teema:"
+            "value" : "Teema"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Thème :"
+            "value" : "Thème"
           }
         },
         "he" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ערכת נושא:"
+            "value" : "ערכת נושא"
           }
         },
         "hi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "थीम:"
+            "value" : "थीम"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tema:"
+            "value" : "Tema"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "テーマ:"
+            "value" : "テーマ"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Thema:"
+            "value" : "Thema"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tema:"
+            "value" : "Tema"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tema:"
+            "value" : "Tema"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Тема:"
+            "value" : "Тема"
           }
         }
       }
@@ -7247,79 +7752,79 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Zeilenumbruch:"
+            "value" : "Lange Zeilen umbrechen"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Word Wrap:"
+            "value" : "Wrap long lines"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ajuste de línea:"
+            "value" : "Ajustar líneas largas"
           }
         },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Rivinvaihto:"
+            "value" : "Rivitä pitkät rivit"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Retour à la ligne :"
+            "value" : "Renvoyer les lignes longues"
           }
         },
         "he" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "גלישת שורות:"
+            "value" : "גלישת שורות ארוכות"
           }
         },
         "hi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "शब्द लपेट:"
+            "value" : "लंबी पंक्तियाँ लपेटें"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "A capo automatico:"
+            "value" : "Manda a capo le righe lunghe"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ワードラップ:"
+            "value" : "長い行を折り返す"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Regelterugloop:"
+            "value" : "Lange regels afbreken"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Translineação:"
+            "value" : "Moldar linhas longas"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Quebra de linha:"
+            "value" : "Quebrar linhas longas"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Перенесення рядків:"
+            "value" : "Переносити довгі рядки"
           }
         }
       }
@@ -7486,6 +7991,90 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Асоціації файлів за замовчуванням"
+          }
+        }
+      }
+    },
+    "window.settings.title" : {
+      "comment" : "Title of the settings window.",
+      "extractionState" : "stale",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Einstellungen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Settings"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajustes"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Asetukset"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réglages"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "הגדרות"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "सेटिंग्ज़"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impostazioni"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設定"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Instellingen"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Definições"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajustes"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Параметри"
           }
         }
       }

--- a/Moped/Preferences.swift
+++ b/Moped/Preferences.swift
@@ -148,6 +148,17 @@ final class Preferences: NSObject, ObservableObject, @unchecked Sendable {
 		}
 	}
 
+	/// Filters the font picker down to fixed-pitch faces. Affects the picker only —
+	/// the stored `font` is never rewritten to satisfy it.
+	@objc dynamic var monospacedFontsOnly: String {
+		get {
+			getStringValue(forKey: "monospacedFontsOnly", otherwiseUse: "No")
+		}
+		set {
+			setStringValue(forKey: "monospacedFontsOnly", to: newValue)
+		}
+	}
+
 	@objc dynamic var fontSize: String {
 		get {
 			getStringValue(forKey: "fontSize", otherwiseUse: "13")
@@ -239,6 +250,10 @@ final class Preferences: NSObject, ObservableObject, @unchecked Sendable {
 
 	var doShowLineNumberRuler: Bool {
 		return showLineNumberRuler == "Yes"
+	}
+
+	var showsMonospacedFontsOnly: Bool {
+		return monospacedFontsOnly == "Yes"
 	}
 
 	var selectedAppIcon: AppIcon {

--- a/Moped/PreferencesView.swift
+++ b/Moped/PreferencesView.swift
@@ -26,14 +26,51 @@ private struct PreferenceOption: Hashable {
 	let label: String
 }
 
+/// Sidebar sections, in display order. Grouping by purpose keeps unrelated settings
+/// from competing for the same visual weight the way one flat list did.
+private enum SettingsSection: String, CaseIterable, Identifiable {
+	case general
+	case appearance
+	case editing
+	case advanced
+
+	var id: String { rawValue }
+
+	var title: LocalizedStringKey {
+		switch self {
+		case .general:    return "pref.section.general"
+		case .appearance: return "pref.section.appearance"
+		case .editing:    return "pref.section.editing"
+		case .advanced:   return "pref.section.advanced"
+		}
+	}
+
+	var symbol: String {
+		switch self {
+		case .general:    return "gearshape"
+		case .appearance: return "paintpalette"
+		case .editing:    return "chevron.left.forwardslash.chevron.right"
+		case .advanced:   return "slider.horizontal.3"
+		}
+	}
+}
+
 struct PreferencesView: View {
 	@ObservedObject var preferences: Preferences
 
-	private let languages: [String]
+	/// Lives in the view, not in `Preferences`: that type documents at its declaration
+	/// that it must stay free of stored properties.
+	@State private var section: SettingsSection = .general
+
+	/// Enumerating every installed font is expensive enough to do once per launch
+	/// rather than once per view init, which the sidebar makes far more frequent.
+	private static let allFonts: [String] = NSFontManager.shared.availableFonts.sorted()
+	private static let monospacedFonts: [String] =
+		(NSFontManager.shared.availableFontNames(with: .fixedPitchFontMask) ?? []).sorted()
+
+	private let languages: [PreferenceOption]
 	private let themes: [PreferenceOption]
-	private let fonts: [String]
-	private let fontSizes: [String]
-	private let yesNoOptions: [PreferenceOption]
+	private let fontSizes: [PreferenceOption]
 	private let launchBehaviorOptions: [PreferenceOption]
 	private let defaultIndentationOptions: [PreferenceOption]
 	private let appIconOptions = Preferences.AppIcon.allCases.map {
@@ -43,16 +80,13 @@ struct PreferencesView: View {
 	init(preferences: Preferences) {
 		self.preferences = preferences
 
-		languages = LanguageCatalog.shared.supportedLanguages
-		themes = MopedTheme.allNames.map {
+		languages = LanguageCatalog.shared.supportedLanguages.map {
+			PreferenceOption(value: $0, label: $0)
+		}
+		themes = MopedTheme.selectableNames.map {
 			PreferenceOption(value: $0, label: ThemeCatalog.localizedName(for: $0))
 		}
-		fonts = NSFontManager.shared.availableFonts.sorted()
-		fontSizes = (9...24).map { String($0) }
-		yesNoOptions = [
-			PreferenceOption(value: "Yes", label: String(localized: "option.yes")),
-			PreferenceOption(value: "No", label: String(localized: "option.no"))
-		]
+		fontSizes = (9...24).map { PreferenceOption(value: String($0), label: String($0)) }
 		launchBehaviorOptions = [
 			PreferenceOption(value: "FileOpenDialog", label: String(localized: "option.file_open_dialog")),
 			PreferenceOption(value: "EmptyEditor", label: String(localized: "option.empty_editor")),
@@ -65,121 +99,206 @@ struct PreferencesView: View {
 		]
 	}
 
+	// MARK: - Layout
+
 	var body: some View {
-		VStack(alignment: .leading, spacing: 12) {
-			PreferenceRow(
-				title: "pref.language.title",
-				selection: Binding(
-					get: { preferences.language },
-					set: { preferences.language = $0 }
-				),
-				options: languages.map { PreferenceOption(value: $0, label: $0) }
-			)
-
-			PreferenceRow(
-				title: "pref.theme.title",
-				selection: Binding(
-					get: { preferences.theme },
-					set: { preferences.theme = $0 }
-				),
-				options: themes
-			)
-
-			PreferenceRow(
-				title: "pref.font.title",
-				selection: Binding(
-					get: { preferences.font },
-					set: { preferences.font = $0 }
-				),
-				options: fonts.map { PreferenceOption(value: $0, label: $0) }
-			)
-
-			PreferenceRow(
-				title: "pref.font_size.title",
-				selection: Binding(
-					get: { preferences.fontSize },
-					set: { preferences.fontSize = $0 }
-				),
-				options: fontSizes.map { PreferenceOption(value: $0, label: $0) }
-			)
-
-			PreferenceRow(
-				title: "pref.word_wrap.title",
-				selection: Binding(
-					get: { preferences.lineWrap },
-					set: { preferences.lineWrap = $0 }
-				),
-				options: yesNoOptions
-			)
-
-			PreferenceRow(
-				title: "pref.line_numbers.title",
-				selection: Binding(
-					get: { preferences.showLineNumberRuler },
-					set: { preferences.showLineNumberRuler = $0 }
-				),
-				options: yesNoOptions
-			)
-
-			PreferenceRow(
-				title: "pref.launch_behavior.title",
-				selection: Binding(
-					get: { preferences.launchBehavior },
-					set: { preferences.launchBehavior = $0 }
-				),
-				options: launchBehaviorOptions
-			)
-
-			PreferenceRow(
-				title: "pref.default_indentation.title",
-				selection: Binding(
-					get: { preferences.defaultIndentation },
-					set: { preferences.defaultIndentation = $0 }
-				),
-				options: defaultIndentationOptions
-			)
-
-			PreferenceRow(
-				title: "pref.active_icon.title",
-				selection: Binding(
-					get: { preferences.appIcon },
-					set: { preferences.appIcon = $0 }
-				),
-				options: appIconOptions
-			)
+		HStack(spacing: 0) {
+			List(SettingsSection.allCases, selection: sidebarSelection) { item in
+				Label(item.title, systemImage: item.symbol)
+					.tag(item)
+			}
+			.listStyle(.sidebar)
+			.frame(width: 170)
 
 			Divider()
 
-			HStack(alignment: .center, spacing: 12) {
-				Text("pref.default_editor.title")
-					.frame(width: 125, alignment: .leading)
+			ScrollView {
+				detail
+					.padding(20)
+					.frame(maxWidth: .infinity, alignment: .leading)
+			}
+		}
+		// Sized by measurement, not by eye. The binding constraints are pt-BR's "At
+		// startup" popup (581pt including padding — the widest control in any of the 13
+		// locales) and Hindi's Appearance pane (206pt tall, Devanagari has taller line
+		// boxes). English needs far less, but one fixed window has to fit the worst case
+		// or that popup silently truncates.
+		.frame(width: 590, height: 210)
+		.navigationTitle("window.settings.title")
+	}
+
+	/// `List` hands back `nil` when a row is deselected, but the detail pane always
+	/// needs a section, so a deselect keeps whichever one was showing.
+	private var sidebarSelection: Binding<SettingsSection?> {
+		Binding(
+			get: { section },
+			set: { section = $0 ?? section }
+		)
+	}
+
+	@ViewBuilder
+	private var detail: some View {
+		VStack(alignment: .leading, spacing: 16) {
+			Text(section.title)
+				.font(.title2)
+				.bold()
+
+			switch section {
+			case .general:    generalPane
+			case .appearance: appearancePane
+			case .editing:    editingPane
+			case .advanced:   advancedPane
+			}
+		}
+	}
+
+	// MARK: - Panes
+
+	private var generalPane: some View {
+		settingsGrid {
+			GridRow {
+				label("pref.launch_behavior.title")
+				picker(binding(\.launchBehavior), options: launchBehaviorOptions)
+			}
+			GridRow {
+				label("pref.active_icon.title")
+				picker(binding(\.appIcon), options: appIconOptions)
+			}
+		}
+	}
+
+	private var appearancePane: some View {
+		settingsGrid {
+			GridRow {
+				label("pref.theme.title")
+				picker(binding(\.theme), options: themes)
+			}
+			GridRow {
+				label("pref.font.title")
+				picker(binding(\.font), options: fontOptions)
+			}
+			GridRow {
+				emptyLabel
+				checkbox("pref.monospaced_only.title", yesNo(\.monospacedFontsOnly))
+			}
+			GridRow {
+				label("pref.font_size.title")
+				picker(binding(\.fontSize), options: fontSizes)
+					.fixedSize()
+			}
+		}
+	}
+
+	private var editingPane: some View {
+		settingsGrid {
+			GridRow {
+				label("pref.language.title")
+				picker(binding(\.language), options: languages)
+			}
+			GridRow {
+				emptyLabel
+				checkbox("pref.word_wrap.title", yesNo(\.lineWrap))
+			}
+			GridRow {
+				emptyLabel
+				checkbox("pref.line_numbers.title", yesNo(\.showLineNumberRuler))
+			}
+			GridRow {
+				label("pref.default_indentation.title")
+				picker(binding(\.defaultIndentation), options: defaultIndentationOptions)
+			}
+		}
+	}
+
+	private var advancedPane: some View {
+		settingsGrid {
+			GridRow {
+				label("pref.default_editor.title")
 				Button("pref.default_editor.button") {
 					AppActions.shared.showDefaultEditorSelector()
 				}
+				.fixedSize()
 			}
 		}
-		.padding(20)
-		.frame(width: 430, height: 410, alignment: .topLeading)
 	}
-}
 
-private struct PreferenceRow: View {
-	let title: LocalizedStringKey
-	@Binding var selection: String
-	let options: [PreferenceOption]
+	// MARK: - Row building
 
-	var body: some View {
-		HStack(alignment: .center, spacing: 12) {
-			Text(title)
-				.frame(width: 125, alignment: .leading)
-			Picker("", selection: $selection) {
-				ForEach(options, id: \.value) { option in
-					Text(option.label)
-						.tag(option.value)
-				}
-			}
-			.labelsHidden()
-			.frame(maxWidth: .infinity, alignment: .leading)
+	/// `Grid` sizes the label column to its widest member, so labels and controls line
+	/// up in every locale — which the old fixed-width label frame could not do.
+	private func settingsGrid<Content: View>(@ViewBuilder rows: () -> Content) -> some View {
+		Grid(alignment: .leadingFirstTextBaseline, horizontalSpacing: 12, verticalSpacing: 12) {
+			rows()
 		}
+	}
+
+	private func label(_ title: LocalizedStringKey) -> some View {
+		Text(title)
+			.gridColumnAlignment(.leading)
+	}
+
+	/// Placeholder for a row whose control is self-labelling, so it still lands in the
+	/// control column rather than starting at the label column.
+	private var emptyLabel: some View {
+		Color.clear
+			.gridCellUnsizedAxes([.horizontal, .vertical])
+	}
+
+	private func picker(_ selection: Binding<String>, options: [PreferenceOption]) -> some View {
+		Picker("", selection: selection) {
+			ForEach(options, id: \.value) { option in
+				Text(option.label)
+					.tag(option.value)
+			}
+		}
+		.labelsHidden()
+		.frame(maxWidth: .infinity, alignment: .leading)
+	}
+
+	/// A self-labelling checkbox for the control column.
+	///
+	/// `fixedSize(horizontal:)` is load-bearing. A `Text` advertises a flexible ideal
+	/// width because it is willing to wrap, so `Grid` sizes the control column to the
+	/// pickers and then squeezes the checkbox caption onto two lines — even with the
+	/// window half empty beside it. Refusing to compress makes the caption report its
+	/// true width, so the column is sized to fit it.
+	private func checkbox(_ title: LocalizedStringKey, _ isOn: Binding<Bool>) -> some View {
+		Toggle(title, isOn: isOn)
+			.toggleStyle(.checkbox)
+			.fixedSize(horizontal: true, vertical: false)
+	}
+
+	// MARK: - Bindings
+
+	private func binding(_ keyPath: ReferenceWritableKeyPath<Preferences, String>) -> Binding<String> {
+		Binding(
+			get: { preferences[keyPath: keyPath] },
+			set: { preferences[keyPath: keyPath] = $0 }
+		)
+	}
+
+	/// Booleans are stored as `"Yes"`/`"No"` strings. Binding a `Bool` over that keeps
+	/// the checkbox honest about what the setting is without disturbing the stored
+	/// representation or the `do…` readers that depend on it.
+	private func yesNo(_ keyPath: ReferenceWritableKeyPath<Preferences, String>) -> Binding<Bool> {
+		Binding(
+			get: { preferences[keyPath: keyPath] == "Yes" },
+			set: { preferences[keyPath: keyPath] = $0 ? "Yes" : "No" }
+		)
+	}
+
+	/// The selected font is always offered, even when it is proportional and the
+	/// monospaced filter is on. Dropping it would leave the picker with no row matching
+	/// its tag, which renders blank — and silently rewriting the preference to fit the
+	/// filter would lose a deliberate choice.
+	private var fontOptions: [PreferenceOption] {
+		let base = preferences.showsMonospacedFontsOnly ? Self.monospacedFonts : Self.allFonts
+		let selected = preferences.font
+		var names = base
+		if !names.contains(selected) {
+			let insertion = names.firstIndex { $0 > selected } ?? names.endIndex
+			names.insert(selected, at: insertion)
+		}
+		return names.map { PreferenceOption(value: $0, label: $0) }
 	}
 }

--- a/Moped/ThemeCatalog.swift
+++ b/Moped/ThemeCatalog.swift
@@ -18,6 +18,7 @@
 //	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 //
 
+import AppKit
 import MopedEditor
 
 /// Resolves the stored theme preference to a `MopedEditor` theme. The themes
@@ -27,8 +28,18 @@ enum ThemeCatalog {
 	/// Look up a theme by name, resolving legacy Highlightr theme strings to the closest
 	/// built-in. Returns the default theme when nothing matches so existing preferences
 	/// don't reset users on first launch.
+	///
+	/// `@MainActor` because the System theme is resolved against `NSApp`'s appearance.
+	/// Both callers live in `EditorState`, which is already main-actor isolated;
+	/// `localizedName(for:)` below touches no app state and stays nonisolated.
+	@MainActor
 	static func theme(named name: String) -> MopedTheme {
 		let key = name.lowercased()
+		if key == MopedTheme.systemName.lowercased() {
+			// Only an opening value: `MopedTextView` re-resolves it against its own
+			// effective appearance, and again whenever that appearance changes.
+			return .system(for: NSApp.effectiveAppearance)
+		}
 		if let direct = MopedTheme.allBuiltIn.first(where: { $0.name.lowercased() == key }) {
 			return direct
 		}
@@ -50,6 +61,7 @@ enum ThemeCatalog {
 	/// which is untranslated but never blank.
 	static func localizedName(for name: String) -> String {
 		switch name {
+		case MopedTheme.systemName:          return String(localized: "option.theme.system")
 		case MopedTheme.defaultLight.name:   return String(localized: "option.theme.default_light")
 		case MopedTheme.defaultDark.name:    return String(localized: "option.theme.default_dark")
 		case MopedTheme.xcodeLike.name:      return String(localized: "option.theme.xcode_like")

--- a/MopedEditor/Sources/MopedEditor/EditorTheme+BuiltIn.swift
+++ b/MopedEditor/Sources/MopedEditor/EditorTheme+BuiltIn.swift
@@ -27,6 +27,11 @@ extension MopedTheme {
 
 	public static let allNames: [String] = allBuiltIn.map(\.name)
 
+	/// Everything the settings picker offers, appearance-following theme first. Kept
+	/// separate from `allNames` because `system` is a function of the appearance rather
+	/// than a fixed theme, so it cannot join `allBuiltIn`.
+	public static let selectableNames: [String] = [systemName] + allNames
+
 	public static let defaultName: String = defaultLight.name
 }
 

--- a/MopedEditor/Sources/MopedEditor/EditorTheme+System.swift
+++ b/MopedEditor/Sources/MopedEditor/EditorTheme+System.swift
@@ -1,0 +1,77 @@
+//
+//  EditorTheme+System.swift
+//
+//  MopedEditor - The homegrown text editor core and syntax highlighter used by Moped.
+//  Copyright © 2019-2026 Roberto Machorro. All rights reserved.
+//
+//	This program is free software: you can redistribute it and/or modify
+//	it under the terms of the GNU General Public License as published by
+//	the Free Software Foundation, either version 3 of the License, or
+//	(at your option) any later version.
+//
+//	This program is distributed in the hope that it will be useful,
+//	but WITHOUT ANY WARRANTY; without even the implied warranty of
+//	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//	GNU General Public License for more details.
+//
+//	You should have received a copy of the GNU General Public License
+//	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import AppKit
+
+extension MopedTheme {
+	/// Stored preference value and identity of the appearance-following theme. Not a
+	/// member of `allBuiltIn`: unlike the fixed themes it cannot be a `static let`,
+	/// because its colours depend on the appearance it is asked about.
+	public static let systemName = "System"
+
+	/// The editor dressed in AppKit's own text colours, resolved against `appearance`.
+	///
+	/// The resolution is eager and the result is a plain sRGB theme. That is deliberate:
+	/// `MopedTheme` is `Sendable` on the promise that it never carries a dynamic or
+	/// catalog colour (see the type's own documentation). Holding `NSColor.textColor`
+	/// would break that promise, so callers rebuild this theme when the effective
+	/// appearance changes instead of relying on a colour to re-resolve itself.
+	///
+	/// Token colours still come from the hand-tuned light/dark palettes. Picking
+	/// "System" means giving up an opinionated set of chrome colours, not giving up
+	/// syntax highlighting.
+	public static func system(for appearance: NSAppearance) -> MopedTheme {
+		let isDark = appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+		let fallback: MopedTheme = isDark ? .defaultDark : .defaultLight
+
+		var background = fallback.background
+		var foreground = fallback.foreground
+		var gutterBackground = fallback.gutterBackground
+		var gutterForeground = fallback.gutterForeground
+		var selection = fallback.selection
+		var caret = fallback.caret
+
+		appearance.performAsCurrentDrawingAppearance {
+			background = sRGB(.textBackgroundColor, or: fallback.background)
+			foreground = sRGB(.textColor, or: fallback.foreground)
+			gutterBackground = sRGB(.controlBackgroundColor, or: fallback.gutterBackground)
+			gutterForeground = sRGB(.secondaryLabelColor, or: fallback.gutterForeground)
+			selection = sRGB(.selectedTextBackgroundColor, or: fallback.selection)
+			caret = sRGB(.textColor, or: fallback.foreground)
+		}
+
+		return MopedTheme(
+			name: systemName,
+			background: background,
+			foreground: foreground,
+			gutterBackground: gutterBackground,
+			gutterForeground: gutterForeground,
+			selection: selection,
+			caret: caret,
+			tokenColors: fallback.tokenColors
+		)
+	}
+
+	/// Flattens a dynamic system colour to components. Must be called with the target
+	/// appearance current, or it resolves against the wrong one.
+	private static func sRGB(_ color: NSColor, or fallback: NSColor) -> NSColor {
+		color.usingColorSpace(.sRGB) ?? fallback
+	}
+}

--- a/MopedEditor/Sources/MopedEditor/EditorTheme.swift
+++ b/MopedEditor/Sources/MopedEditor/EditorTheme.swift
@@ -36,8 +36,13 @@ public struct MopedTheme: Sendable {
 	public let gutterBackground: NSColor
 	public let gutterForeground: NSColor
 	public let selection: NSColor
+	public let caret: NSColor
 	public let tokenColors: [String: NSColor]
 
+	/// `caret` defaults to the inverse of the background, which is what the editor has
+	/// always drawn. Themes whose background is a system colour pass it explicitly —
+	/// inverting the system text background gives a caret that is wrong in both
+	/// appearances.
 	public init(
 		name: String,
 		background: NSColor,
@@ -45,6 +50,7 @@ public struct MopedTheme: Sendable {
 		gutterBackground: NSColor,
 		gutterForeground: NSColor,
 		selection: NSColor,
+		caret: NSColor? = nil,
 		tokenColors: [String: NSColor]
 	) {
 		self.name = name
@@ -53,11 +59,28 @@ public struct MopedTheme: Sendable {
 		self.gutterBackground = gutterBackground
 		self.gutterForeground = gutterForeground
 		self.selection = selection
+		self.caret = caret ?? Self.inverse(of: background)
 		self.tokenColors = tokenColors
 	}
 
 	/// Color for a token kind, falling back to the plain foreground.
 	public func color(for kind: TokenKind) -> NSColor {
 		tokenColors[kind.rawValue] ?? foreground
+	}
+
+	private static func inverse(of color: NSColor) -> NSColor {
+		let resolved = color.usingColorSpace(.sRGB)
+			?? color.usingColorSpace(.deviceRGB)
+			?? color.usingColorSpace(.genericRGB)
+
+		guard let rgb = resolved else {
+			return .black
+		}
+		var red: CGFloat = 1
+		var green: CGFloat = 1
+		var blue: CGFloat = 1
+		var alpha: CGFloat = 1
+		rgb.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+		return NSColor(red: 1 - red, green: 1 - green, blue: 1 - blue, alpha: alpha)
 	}
 }

--- a/MopedEditor/Sources/MopedEditor/MopedTextView+CurrentLine.swift
+++ b/MopedEditor/Sources/MopedEditor/MopedTextView+CurrentLine.swift
@@ -53,7 +53,7 @@ extension MopedTextView {
 		guard lineRect.intersects(rect) else {
 			return
 		}
-		theme.selection.withAlphaComponent(0.35).setFill()
+		resolvedTheme.selection.withAlphaComponent(0.35).setFill()
 		lineRect.fill()
 	}
 

--- a/MopedEditor/Sources/MopedEditor/MopedTextView+Editing.swift
+++ b/MopedEditor/Sources/MopedEditor/MopedTextView+Editing.swift
@@ -179,7 +179,7 @@ extension MopedTextView {
 
 		textStorage.replaceCharacters(in: lineRange, with: transformedBlock)
 		textStorage.setAttributes(
-			[.font: editorFont, .foregroundColor: theme.foreground],
+			[.font: editorFont, .foregroundColor: resolvedTheme.foreground],
 			range: NSRange(location: lineRange.location, length: (transformedBlock as NSString).length)
 		)
 		didChangeText()

--- a/MopedEditor/Sources/MopedEditor/MopedTextView.swift
+++ b/MopedEditor/Sources/MopedEditor/MopedTextView.swift
@@ -217,20 +217,42 @@ public final class MopedTextView: NSTextView {
 
 	// MARK: Appearance
 
+	/// The theme actually painted. The System theme is rebuilt against this view's own
+	/// effective appearance so it tracks Auto light/dark; every other theme is fixed and
+	/// passes straight through.
+	var resolvedTheme: MopedTheme {
+		theme.name == MopedTheme.systemName ? .system(for: effectiveAppearance) : theme
+	}
+
+	/// Re-resolves the System theme when the user (or the schedule) flips light/dark.
+	/// A repaint alone would not be enough: token colours live as layout-manager
+	/// temporary attributes, so the highlighter has to be handed the new palette and
+	/// re-run, which assigning `highlighter.theme` in `applyTheme()` does.
+	public override func viewDidChangeEffectiveAppearance() {
+		super.viewDidChangeEffectiveAppearance()
+		guard theme.name == MopedTheme.systemName else {
+			return
+		}
+		applyTheme()
+	}
+
 	private func applyTheme() {
-		highlighter.theme = theme
-		backgroundColor = theme.background
-		textColor = theme.foreground
-		insertionPointColor = Self.caretColor(using: theme.background)
-		selectedTextAttributes = [.backgroundColor: theme.selection]
+		// Resolved once per pass: `system(for:)` rebuilds a whole palette, and several
+		// of the assignments below would otherwise each trigger their own resolution.
+		let resolved = resolvedTheme
+		highlighter.theme = resolved
+		backgroundColor = resolved.background
+		textColor = resolved.foreground
+		insertionPointColor = resolved.caret
+		selectedTextAttributes = [.backgroundColor: resolved.selection]
 		typingAttributes = baseAttributes()
-		enclosingScrollView?.backgroundColor = theme.background
+		enclosingScrollView?.backgroundColor = resolved.background
 		textStorage?.addAttribute(
 			.foregroundColor,
-			value: theme.foreground,
+			value: resolved.foreground,
 			range: NSRange(location: 0, length: textStorage?.length ?? 0)
 		)
-		lineNumberRuler?.theme = theme
+		lineNumberRuler?.theme = resolved
 		needsDisplay = true
 	}
 
@@ -247,7 +269,7 @@ public final class MopedTextView: NSTextView {
 	}
 
 	private func baseAttributes() -> [NSAttributedString.Key: Any] {
-		[.font: editorFont, .foregroundColor: theme.foreground]
+		[.font: editorFont, .foregroundColor: resolvedTheme.foreground]
 	}
 
 	private func installLineNumberRuler() {
@@ -297,23 +319,6 @@ public final class MopedTextView: NSTextView {
 	private static func gutterFont(matching font: NSFont) -> NSFont {
 		let size = font.pointSize * 0.9
 		return NSFont.userFixedPitchFont(ofSize: size) ?? NSFont.systemFont(ofSize: size)
-	}
-
-	/// Caret color as the inverse of the background, matching the previous editor.
-	private static func caretColor(using color: NSColor) -> NSColor {
-		let resolved = color.usingColorSpace(.sRGB)
-			?? color.usingColorSpace(.deviceRGB)
-			?? color.usingColorSpace(.genericRGB)
-
-		guard let rgb = resolved else {
-			return .black
-		}
-		var red: CGFloat = 1
-		var green: CGFloat = 1
-		var blue: CGFloat = 1
-		var alpha: CGFloat = 1
-		rgb.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
-		return NSColor(red: 1 - red, green: 1 - green, blue: 1 - blue, alpha: alpha)
 	}
 
 }

--- a/MopedEditor/Sources/MopedEditor/MopedTextView.swift
+++ b/MopedEditor/Sources/MopedEditor/MopedTextView.swift
@@ -57,8 +57,17 @@ public final class MopedTextView: NSTextView {
 	public var defaultFontSize: CGFloat = 13.0
 
 	public var theme: MopedTheme {
-		didSet { applyTheme() }
+		didSet { refreshResolvedTheme() }
 	}
+
+	/// The theme actually painted, cached rather than derived on demand.
+	///
+	/// For every theme but System this is just `theme`. For System it is a snapshot of
+	/// AppKit's colours taken against this view's effective appearance, and rebuilding
+	/// that snapshot is not free — `drawBackground(in:)` reads it on every repaint, so
+	/// deriving it per access would re-resolve a whole palette while scrolling.
+	/// Invalidated only by `theme` and by `viewDidChangeEffectiveAppearance()`.
+	private(set) var resolvedTheme: MopedTheme
 
 	/// Language name (id or alias, e.g. `swift`, `shell`). Unknown names, including
 	/// `plaintext`, render without highlighting.
@@ -115,13 +124,18 @@ public final class MopedTextView: NSTextView {
 		let textView = MopedTextView(theme: theme, font: resolvedFont)
 		scrollView.documentView = textView
 		textView.installLineNumberRuler()
-		textView.applyTheme()
+		// Not `applyTheme()`: the System theme has to resolve against the live view's
+		// effective appearance, which only exists now that the view is constructed.
+		textView.refreshResolvedTheme()
 		textView.applyContainerSizing()
 		return (scrollView, textView)
 	}
 
 	private init(theme: MopedTheme, font: NSFont) {
 		self.theme = theme
+		// `effectiveAppearance` needs a live view, so the System theme cannot resolve
+		// until after `super.init`. `scrollableEditor` calls `refreshResolvedTheme()`.
+		self.resolvedTheme = theme
 		self.editorFont = font
 		self.language = "plaintext"
 		self.highlighter = SyntaxHighlighter(theme: theme)
@@ -217,13 +231,6 @@ public final class MopedTextView: NSTextView {
 
 	// MARK: Appearance
 
-	/// The theme actually painted. The System theme is rebuilt against this view's own
-	/// effective appearance so it tracks Auto light/dark; every other theme is fixed and
-	/// passes straight through.
-	var resolvedTheme: MopedTheme {
-		theme.name == MopedTheme.systemName ? .system(for: effectiveAppearance) : theme
-	}
-
 	/// Re-resolves the System theme when the user (or the schedule) flips light/dark.
 	/// A repaint alone would not be enough: token colours live as layout-manager
 	/// temporary attributes, so the highlighter has to be handed the new palette and
@@ -233,26 +240,33 @@ public final class MopedTextView: NSTextView {
 		guard theme.name == MopedTheme.systemName else {
 			return
 		}
+		refreshResolvedTheme()
+	}
+
+	/// Recomputes `resolvedTheme` and repaints. The only two things that can invalidate
+	/// the cache are a new `theme` and a change of effective appearance, so those are
+	/// the only callers.
+	private func refreshResolvedTheme() {
+		resolvedTheme = theme.name == MopedTheme.systemName
+			? .system(for: effectiveAppearance)
+			: theme
 		applyTheme()
 	}
 
 	private func applyTheme() {
-		// Resolved once per pass: `system(for:)` rebuilds a whole palette, and several
-		// of the assignments below would otherwise each trigger their own resolution.
-		let resolved = resolvedTheme
-		highlighter.theme = resolved
-		backgroundColor = resolved.background
-		textColor = resolved.foreground
-		insertionPointColor = resolved.caret
-		selectedTextAttributes = [.backgroundColor: resolved.selection]
+		highlighter.theme = resolvedTheme
+		backgroundColor = resolvedTheme.background
+		textColor = resolvedTheme.foreground
+		insertionPointColor = resolvedTheme.caret
+		selectedTextAttributes = [.backgroundColor: resolvedTheme.selection]
 		typingAttributes = baseAttributes()
-		enclosingScrollView?.backgroundColor = resolved.background
+		enclosingScrollView?.backgroundColor = resolvedTheme.background
 		textStorage?.addAttribute(
 			.foregroundColor,
-			value: resolved.foreground,
+			value: resolvedTheme.foreground,
 			range: NSRange(location: 0, length: textStorage?.length ?? 0)
 		)
-		lineNumberRuler?.theme = resolved
+		lineNumberRuler?.theme = resolvedTheme
 		needsDisplay = true
 	}
 

--- a/MopedEditor/Tests/MopedEditorTests/EditorIntegrationTests.swift
+++ b/MopedEditor/Tests/MopedEditorTests/EditorIntegrationTests.swift
@@ -121,6 +121,58 @@ final class EditorIntegrationTests: EditorTestCase {
 		XCTAssertEqual(textView.string, "let x = 1\n", "Re-theming must not disturb the text")
 	}
 
+	/// The System theme is the only one that has to re-resolve itself: its colours are
+	/// snapshots of AppKit's, taken against whatever appearance was current when the
+	/// snapshot was made.
+	func testSystemThemeFollowsTheViewAppearance() throws {
+		let (_, textView) = makeEditor(theme: .system(for: try XCTUnwrap(NSAppearance(named: .aqua))))
+		textView.appearance = NSAppearance(named: .aqua)
+		textView.language = "swift"
+		textView.setPlainText("let x = 1\n")
+		drainHighlightPasses()
+
+		let lightBackground = try XCTUnwrap(textView.backgroundColor.usingColorSpace(.sRGB))
+		let keywordLocation = (textView.string as NSString).range(of: "let").location
+		XCTAssertEqual(
+			color(at: keywordLocation, in: textView),
+			MopedTheme.defaultLight.color(for: .keyword),
+			"the light appearance should use the light token palette"
+		)
+
+		textView.appearance = NSAppearance(named: .darkAqua)
+		drainHighlightPasses()
+
+		let darkBackground = try XCTUnwrap(textView.backgroundColor.usingColorSpace(.sRGB))
+		XCTAssertLessThan(
+			darkBackground.brightnessComponent,
+			lightBackground.brightnessComponent,
+			"switching to dark should darken the editor background"
+		)
+		XCTAssertEqual(
+			color(at: keywordLocation, in: textView),
+			MopedTheme.defaultDark.color(for: .keyword),
+			"token colors are layout-manager temporary attributes, so they only follow "
+				+ "the appearance if the highlighter is re-run"
+		)
+		XCTAssertEqual(textView.string, "let x = 1\n", "Re-resolving must not disturb the text")
+	}
+
+	/// A fixed theme must ignore the appearance entirely — picking Solarized Dark and
+	/// then switching to Light must not repaint the editor.
+	func testFixedThemeIgnoresTheViewAppearance() {
+		let (_, textView) = makeEditor(theme: .solarizedDark)
+		textView.appearance = NSAppearance(named: .aqua)
+		textView.setPlainText("let x = 1\n")
+		drainHighlightPasses()
+
+		XCTAssertEqual(textView.backgroundColor, MopedTheme.solarizedDark.background)
+
+		textView.appearance = NSAppearance(named: .darkAqua)
+		drainHighlightPasses()
+
+		XCTAssertEqual(textView.backgroundColor, MopedTheme.solarizedDark.background)
+	}
+
 	func testDisablingHighlightingClearsColors() {
 		let (_, textView) = makeEditor()
 		textView.language = "swift"

--- a/MopedEditor/Tests/MopedEditorTests/ThemeTests.swift
+++ b/MopedEditor/Tests/MopedEditorTests/ThemeTests.swift
@@ -45,4 +45,79 @@ final class ThemeTests: XCTestCase {
 		let theme = MopedTheme.defaultLight
 		XCTAssertEqual(theme.color(for: .plain), theme.foreground)
 	}
+
+	// MARK: - System theme
+
+	/// `system` is deliberately absent from `allBuiltIn`: it is a function of the
+	/// appearance, so it cannot be one of the fixed themes.
+	func testSystemThemeIsSelectableButNotBuiltIn() {
+		XCTAssertFalse(MopedTheme.allNames.contains(MopedTheme.systemName))
+		XCTAssertEqual(MopedTheme.selectableNames.first, MopedTheme.systemName)
+		XCTAssertEqual(MopedTheme.selectableNames.count, MopedTheme.allNames.count + 1)
+	}
+
+	func testSystemThemeFollowsAppearance() throws {
+		let light = try XCTUnwrap(NSAppearance(named: .aqua))
+		let dark = try XCTUnwrap(NSAppearance(named: .darkAqua))
+
+		let lightTheme = MopedTheme.system(for: light)
+		let darkTheme = MopedTheme.system(for: dark)
+
+		XCTAssertEqual(lightTheme.name, MopedTheme.systemName)
+		XCTAssertEqual(darkTheme.name, MopedTheme.systemName)
+		XCTAssertGreaterThan(
+			try brightness(of: lightTheme.background),
+			try brightness(of: darkTheme.background),
+			"the light appearance should produce the lighter editor background"
+		)
+		XCTAssertLessThan(
+			try brightness(of: lightTheme.foreground),
+			try brightness(of: darkTheme.foreground),
+			"the light appearance should produce the darker editor text"
+		)
+	}
+
+	/// The `Sendable` contract on `MopedTheme` requires plain component colours, so the
+	/// system theme has to have flattened every dynamic colour it started from.
+	func testSystemThemeCarriesNoDynamicColors() throws {
+		let theme = MopedTheme.system(for: try XCTUnwrap(NSAppearance(named: .darkAqua)))
+		for color in [
+			theme.background, theme.foreground, theme.gutterBackground,
+			theme.gutterForeground, theme.selection, theme.caret
+		] {
+			XCTAssertEqual(color.colorSpace, .sRGB, "\(color) was not flattened to sRGB")
+		}
+	}
+
+	/// Picking System gives up opinionated chrome, not syntax highlighting.
+	func testSystemThemeColorsEveryTokenKind() throws {
+		for appearance in [NSAppearance.Name.aqua, .darkAqua] {
+			let theme = MopedTheme.system(for: try XCTUnwrap(NSAppearance(named: appearance)))
+			for kind in TokenKind.allCases where kind != .plain {
+				XCTAssertNotNil(
+					theme.tokenColors[kind.rawValue],
+					"System (\(appearance.rawValue)) is missing a color for \(kind.rawValue)"
+				)
+			}
+		}
+	}
+
+	/// The caret is the one colour that cannot be derived by inverting the background:
+	/// inverting the system text background lands on a near-invisible grey.
+	func testSystemThemeCaretIsTheTextColorNotAnInversion() throws {
+		let theme = MopedTheme.system(for: try XCTUnwrap(NSAppearance(named: .darkAqua)))
+		XCTAssertEqual(theme.caret, theme.foreground)
+	}
+
+	func testFixedThemesStillInvertTheirBackgroundForTheCaret() {
+		// Default Light is pure white, so its caret must come out pure black.
+		let caret = try? XCTUnwrap(MopedTheme.defaultLight.caret.usingColorSpace(.sRGB))
+		XCTAssertEqual(caret?.redComponent ?? 1, 0, accuracy: 0.001)
+		XCTAssertEqual(caret?.greenComponent ?? 1, 0, accuracy: 0.001)
+		XCTAssertEqual(caret?.blueComponent ?? 1, 0, accuracy: 0.001)
+	}
+
+	private func brightness(of color: NSColor) throws -> CGFloat {
+		try XCTUnwrap(color.usingColorSpace(.sRGB)).brightnessComponent
+	}
 }

--- a/manual-checklist.md
+++ b/manual-checklist.md
@@ -10,7 +10,13 @@
 - [ ] Open an XML file, an `Info.plist`, and an `.svg` — the `<?xml … ?>` prolog, tag names, and quoted attribute values are all colored; a multiline `<![CDATA[ … ]]>` stays literal and markup after it highlights again.
 - [ ] Open a language with no definition yet (e.g. Dart, AutoHotkey) — shows plain, no crash.
 - [ ] Toggle each theme in Preferences — background, foreground, gutter, and syntax token colors all update on the open document, in place, without the scroll position jumping.
+- [ ] Select the System theme — editor uses the system text colors; flip System Settings → Appearance between Light and Dark with a document open and the background, text, selection, gutter, caret, and syntax colors all follow without reopening the file.
 - [ ] Change font and font size in Preferences — propagates to the editor and to the gutter.
+- [ ] Settings window — titled "Settings", sidebar lists General / Appearance / Editing / Advanced, each pane's labels and controls line up in one column.
+- [ ] Settings in a non‑English locale (German is the longest) — no label truncation and the control column stays aligned.
+- [ ] "Show only monospaced fonts" — checking it shrinks the font list to fixed‑pitch faces; with a proportional font already selected (e.g. Helvetica) the picker still shows it rather than going blank, and the stored font is not rewritten.
+- [ ] Wrap long lines / Show line numbers are checkboxes, not Yes/No pickers, and still drive the editor.
+- [ ] Advanced → Manage… renders as a button (not a popup) and opens Default File Associations.
 - [ ] Cmd‑+, Cmd‑−, Cmd‑0 — increase/decrease/reset font size.
 - [ ] Tab key with no selection: hard‑tab file inserts \t; 2‑space file inserts 2 spaces aligned to column.
 - [ ] Tab/Shift‑Tab with multi‑line selection — indents/outdents block.
@@ -34,3 +40,6 @@
 - [ ] External file change → reload alert → reload — still works.
 - [ ] Print Source — still produces a plain monospace print (SourcePrintView untouched).
 - [ ] MopedCLI moped --wait — unaffected.
+- [ ] On Launch = Empty Editor, then `moped <file>` — only that file opens; no extra untitled window appears on top of it. Launch from Finder with no file — one untitled window.
+- [ ] On Launch = File Open Dialog, then `moped <file>` — only that file opens, no panel. Launch from Finder with no file — the open panel appears.
+- [ ] On Launch = Reopen Previous — open two files, quit, relaunch: both come back at their saved frames. Close both, quit, relaunch: one untitled window. Quit, then `moped <file>`: only that file, no session restore.


### PR DESCRIPTION
Rebuilds the Settings window and fixes two behaviors it exposed. Done as five passes; each was verified in the running app before moving on.

## Settings window

Before, it was one flat `VStack` of nine pickers with every label pinned to a guessed 125pt frame — nothing lined up, and unrelated settings competed for the same visual weight.

- **Sidebar grouping** — General, Appearance, Editing, Advanced.
- **Column alignment** — a `Grid` replaces the fixed-width label column, so labels and controls line up in *every* locale, not just English.
- **Honest controls** — `Manage…` is a real button instead of being styled like a picker; Word Wrap and Line Numbers are checkboxes instead of Yes/No dropdowns. Both still store `"Yes"`/`"No"`, so `Preferences` and its readers are unchanged.
- **New:** "Show only monospaced fonts" filters the font picker (679 → 19 faces here).
- Window is titled **Settings**; captions reworded and de-coloned across all 13 locales.

## System theme

A new theme that hands the editor over to AppKit's own colors and follows Auto Light/Dark.

`MopedTheme` is `Sendable` on a documented promise that it never carries a dynamic or catalog `NSColor`. Rather than break that, `MopedTheme.system(for:)` **resolves** system colors against a given `NSAppearance` into concrete sRGB, and `MopedTextView` rebuilds the theme in `viewDidChangeEffectiveAppearance`. Token colors still come from the light/dark palettes — picking System gives up opinionated chrome, not syntax highlighting.

## Launch behavior

`On Launch = Empty Editor` could drop a spurious untitled window on top of a file passed to `moped <file>`. The old guard checked `documents.isEmpty` on the main actor, but `kAEOpenDocuments` arrives asynchronously and `MopedDocument.init(configuration:)` is `nonisolated` — it was a race, not a check. Now keyed off `NSApplication.launchIsDefaultUserInfoKey`, which Launch Services sets up front.

`Reopen Previous` now falls back to an empty editor when nothing restores, and won't resurrect a session on a Dock-icon reopen.

## Notes for review

Three things worth knowing:

- **`fixedSize(horizontal:)` on the checkbox captions is load-bearing.** `Text` advertises a flexible ideal width because it's willing to wrap, so `Grid` sized the control column to the pickers and squeezed captions onto two lines with the window half empty beside them. This was also what made the window oversized in the first place.
- **`ThemeCatalog.theme(named:)` is now `@MainActor`** — it reads `NSApp`'s appearance. Both callers were already main-actor isolated; `localizedName(for:)` stays nonisolated.
- **SwiftUI's `DocumentGroup` never calls `applicationOpenUntitledFile`.** I instrumented both untitled-file hooks and got zero calls, which is why the launch decision stays in `applicationDidFinishLaunching` — it has to preempt the open panel `DocumentGroup` presents on its own.

## Verification

All four CI gates pass locally: localization check, `swiftlint --strict` (76 files, 0 violations), `swift test --package-path MopedEditor` (**125 tests**, up from 117), and `xcodebuild` with **zero warnings**.

Beyond the gates:

- **Window sizing measured, not eyeballed** — 52 pane/locale combinations (4 panes × 13 languages) screenshotted and their ink bounding boxes computed. Final `590 × 210` is bounded by pt-BR's "At startup" popup (580pt) and Hindi's Appearance pane (206pt, taller Devanagari line boxes). Nothing clips, scrolls, or wraps. 560pt was tempting but truncated that pt-BR popup.
- **Appearance switching is covered by a test**, not a screenshot — `testSystemThemeFollowsTheViewAppearance` asserts both the background and the token palette follow. I mutation-tested it (removed `applyTheme()` from the override) and confirmed it fails, so it isn't passing vacuously.
- **All seven launch permutations** exercised against the built app, including the original bug.

`manual-checklist.md` gains entries for the System theme, the settings layout, the font filter, and the three launch-behavior cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)