### PR TITLE
Carry the document type across a save in both directions

### DIFF
--- a/Moped/EditorView.swift
+++ b/Moped/EditorView.swift
@@ -41,6 +41,12 @@ struct EditorView: View {
 						applyFileType(document.model.docTypeName)
 					}
 				}
+				// The first save of an untitled document adopts the type chosen in the Save
+				// panel, which changes the language underneath the editor. The picker and the
+				// status bar read the model directly; the text view has to be told.
+				.onChange(of: document.model.docTypeLanguage) { _, newValue in
+					editorState.applyLanguage(newValue)
+				}
 
 			HStack(spacing: 12) {
 				Text(document.model.docTypeName)
@@ -98,15 +104,34 @@ struct EditorView: View {
 		)
 	}
 
-	/// Writes the type onto *this* view's document. `currentDocument` is whichever
-	/// document is frontmost, which is not necessarily this one — during the
-	/// launch-time reopen, several documents are opened in a row while another is key.
-	private func applyFileType(_ typeName: String) {
-		guard let url = document.fileURL,
-			  let nsDocument = NSDocumentController.shared.document(for: url) else {
+	/// Writes the type onto *this* view's document, which is what the Save panel reads to
+	/// preselect its File Type popup. `currentDocument` is whichever document is frontmost,
+	/// which is not necessarily this one — during the launch-time reopen, several documents
+	/// are opened in a row while another is key.
+	private func applyFileType(_ typeName: String, attempt: Int = 0) {
+		guard let nsDocument = hostingNSDocument else {
+			// An untitled document is only reachable through its window, and `onAppear` can
+			// run before the text view has one. Same bounded retry as the initial-focus
+			// path in `TextEditorRepresentable.Coordinator`.
+			guard attempt < 10 else {
+				return
+			}
+			DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+				applyFileType(typeName, attempt: attempt + 1)
+			}
 			return
 		}
 		nsDocument.fileType = typeName
+	}
+
+	/// By URL when there is one — exact, and independent of the view being in a window.
+	/// An untitled document has no URL, so it is found through the window hosting this
+	/// editor, which is the same pairing `AppDelegate` does in the other direction.
+	private var hostingNSDocument: NSDocument? {
+		if let url = document.fileURL {
+			return NSDocumentController.shared.document(for: url)
+		}
+		return editorState.textView?.window?.windowController?.document as? NSDocument
 	}
 
 	private var documentContentBinding: Binding<String> {

--- a/Moped/MopedDocument.swift
+++ b/Moped/MopedDocument.swift
@@ -246,12 +246,29 @@ final class MopedDocument: ReferenceFileDocument, ObservableObject, @unchecked S
 		if model.content.data(using: model.encoding) == nil {
 			model.encoding = .utf8
 		}
+		adoptContentTypeOnFirstSave(contentType)
 		return Snapshot(
 			content: model.content,
 			typeName: contentType.identifier,
 			typeLanguage: model.docTypeLanguage,
 			encoding: model.encoding
 		)
+	}
+
+	/// An untitled document is saved with whatever type the user picked in the Save panel,
+	/// which is the first time it has a type at all. Adopt it so the editor highlights what
+	/// was actually written instead of staying on the new-document default.
+	///
+	/// Restricted to the first save deliberately. On a document that already has a URL, a
+	/// plain Cmd-S would otherwise reset the language whenever `contentType` is derived from
+	/// the file on disk rather than from the type the status-bar picker set — which is how a
+	/// `.txt` the user is editing as Python would silently fall back to `plaintext`.
+	private func adoptContentTypeOnFirstSave(_ contentType: UTType) {
+		guard fileURL == nil, contentType.identifier != model.docTypeName else {
+			return
+		}
+		model.docTypeName = contentType.identifier
+		model.docTypeLanguage = model.getLanguageForType(typeName: contentType.identifier)
 	}
 
 	func fileWrapper(snapshot: Snapshot, configuration: WriteConfiguration) throws -> FileWrapper {

--- a/Moped/MopedDocument.swift
+++ b/Moped/MopedDocument.swift
@@ -35,6 +35,11 @@ import UniformTypeIdentifiers
 /// mutation arrives through SwiftUI bindings on the main actor. The one field written
 /// off-main afterwards is `suppressWatchUntil`, from `fileWrapper` during a save, and it
 /// is a `Date` guarding a debounce — a stale read re-prompts a reload at worst.
+///
+/// `snapshot(contentType:)` is the other method the save can call off the main thread. It
+/// reads the model to build the snapshot, which is the handoff working as intended, and
+/// hops to the main actor for the one thing it writes back — see
+/// `adoptContentTypeOnFirstSave`.
 final class MopedDocument: ReferenceFileDocument, ObservableObject, @unchecked Sendable {
 	/// Largest file Moped will open.
 	///
@@ -263,12 +268,35 @@ final class MopedDocument: ReferenceFileDocument, ObservableObject, @unchecked S
 	/// plain Cmd-S would otherwise reset the language whenever `contentType` is derived from
 	/// the file on disk rather than from the type the status-bar picker set — which is how a
 	/// `.txt` the user is editing as Python would silently fall back to `plaintext`.
+	///
+	/// The decision is made here, on whatever thread the save runs on, but applied on the
+	/// main actor: `snapshot(contentType:)` carries no isolation in the protocol, and the
+	/// type and language are `@Published`. Reading the model here is what this method
+	/// already exists to do; publishing from the save's thread is not.
 	private func adoptContentTypeOnFirstSave(_ contentType: UTType) {
-		guard fileURL == nil, contentType.identifier != model.docTypeName else {
+		let typeName = contentType.identifier
+		let previousTypeName = model.docTypeName
+		guard fileURL == nil, typeName != previousTypeName else {
 			return
 		}
-		model.docTypeName = contentType.identifier
-		model.docTypeLanguage = model.getLanguageForType(typeName: contentType.identifier)
+		let language = model.getLanguageForType(typeName: typeName)
+
+		DispatchQueue.main.async { [self] in
+			MainActor.assumeIsolated {
+				adoptTypeName(typeName, language: language, ifStillAt: previousTypeName)
+			}
+		}
+	}
+
+	/// Applies the adopted type unless the picker moved while the write was in flight —
+	/// an explicit choice by the user beats one inferred from the save.
+	@MainActor
+	private func adoptTypeName(_ typeName: String, language: String, ifStillAt previousTypeName: String) {
+		guard model.docTypeName == previousTypeName else {
+			return
+		}
+		model.docTypeName = typeName
+		model.docTypeLanguage = language
 	}
 
 	func fileWrapper(snapshot: Snapshot, configuration: WriteConfiguration) throws -> FileWrapper {

--- a/Moped/TextFileModel.swift
+++ b/Moped/TextFileModel.swift
@@ -21,6 +21,7 @@
 import Combine
 import Foundation
 import MopedEditor
+import UniformTypeIdentifiers
 
 class TextFileModel: NSObject, ObservableObject {
 	@Published var content: String
@@ -128,9 +129,19 @@ extension TextFileModel {
 		return LanguageRegistry.canonicalID(for: name) ?? "plaintext"
 	}
 
+	/// Reverse of `languagesFromUTI`, and the source of the type a Save panel preselects.
+	///
+	/// Identifiers the system cannot resolve are skipped: several plist keys name types
+	/// nobody declares (`public.markdown`, `com.unknown.md`), and picking one would hand
+	/// out an identifier that is absent from `readableContentTypes` — which is built by
+	/// filtering the same keys through `UTType(_:)` — so the save panel would have nothing
+	/// to select. Markdown was the one language this actually hit.
 	private static let utiFromLanguages: [String: String] = {
 		var result: [String: String] = [:]
 		for (uti, language) in languagesFromUTI {
+			guard UTType(uti) != nil else {
+				continue
+			}
 			if let existing = result[language] {
 				if uti.hasPrefix("public.") && !existing.hasPrefix("public.") {
 					result[language] = uti

--- a/manual-checklist.md
+++ b/manual-checklist.md
@@ -49,6 +49,9 @@
 - [ ] UTF‑16 file with a BOM (`printf 'a\nb\n' | iconv -f UTF-8 -t UTF-16 > f.txt`) — still opens as text.
 - [ ] UTF‑8 file with a BOM — still opens as text.
 - [ ] Save, close, reopen — content round‑trips through TextFileModel.
+- [ ] New document, pick `markdown` in the bottom picker, Cmd‑S — the Save panel's File Type is already Markdown and the name field gets `.md`. The status bar reads `net.daringfireball.markdown`; `public.markdown` there means the language→UTI map handed out a type nothing declares.
+- [ ] New document, leave the picker alone, Cmd‑S, choose Markdown (or Python) in the File Type popup — after saving, the picker and the highlighting switch to that language. Choosing plain text leaves it `plaintext`.
+- [ ] Open an existing `.txt`, set the picker to `python`, Cmd‑S — the picker stays `python`; a save must never reset a hand‑picked language.
 - [ ] External file change → reload alert → reload — still works.
 - [ ] Print Source — still produces a plain monospace print (SourcePrintView untouched).
 - [ ] MopedCLI moped --wait — unaffected.


### PR DESCRIPTION
Saving a new document as Markdown left it highlighting as `plaintext`, and a new document with a language already picked opened the Save panel on Plain Text File. Both halves of the same gap — the type the Save panel deals in and the language the editor deals in never met. Closes the first bullet of `TODO.md`.

## What was in the way

**`applyFileType` skipped untitled documents.** `EditorView.applyFileType` is the only place that writes the picked type onto the `NSDocument`, which is what AppKit's save panel reads to preselect its File Format popup. It guarded on `document.fileURL`, which is `nil` for an untitled document — so it did nothing in exactly the case that needed it, which is why the same flow already worked on a file opened from disk. An untitled document is now found through the window hosting the editor, the pairing `AppDelegate` already does in the other direction. `onAppear` can run before the text view is in a window, hence the bounded retry, borrowed from the initial-focus path in `TextEditorRepresentable`.

**Nothing wrote the saved type back to the live model.** `fileWrapper` builds a throwaway `TextFileModel` from the save's content type, `data(ofType:)` recomputes `docTypeLanguage` on that throwaway, and it is discarded. `snapshot(contentType:)` adopts it instead — that method already exists to reconcile the live model with the save's parameters, which is where the encoding upgrade lives.

**`markdown` mapped to a UTI nothing declares.** `getUTTypeForLanguage("markdown")` returned `public.markdown`, which `UTType(_:)` cannot resolve. `readableContentTypes` is built by filtering the same plist keys through `UTType(_:)`, so the identifier was absent from the popup's list — a fixed `applyFileType` could not have preselected Markdown, the one language the todo named. `utiFromLanguages` now skips identifiers that do not resolve before applying its existing `public.`-prefix preference, so markdown lands on `net.daringfireball.markdown`, which `Info.plist` imports. Checked against all 110 mapped languages: markdown was the only one affected, and none are unresolvable now.

## Scope

Adoption is restricted to `fileURL == nil`, the first save of a document that has never had a type. That guard is load-bearing rather than conservative: a plain Cmd-S on a `.txt` the user had switched to `python` would otherwise reset the language every time it was saved, if SwiftUI derives `contentType` from the file rather than from `NSDocument.fileType`. Save As to a different type on an already-saved document is deliberately left alone.

## Verification

Gates: SwiftLint clean on the changed files, 164/164 `MopedEditor` tests, localization check passes (no new strings).

Driven by hand in a Debug build:

- New doc → picker set to `markdown` → Cmd-S → Save panel already reads "Markdown text file".
- New doc left on plaintext → Cmd-S → chose Markdown → saved as `Untitled.md`, status bar switched to `net.daringfireball.markdown`, picker to `markdown`, heading and inline code colored immediately.
- Regression: opened `notes.txt`, set picker to `python`, Cmd-S → picker held at `python`. Log clean of "publishing changes from background threads", so `snapshot(contentType:)` is on the main thread as the placement assumes.

Three matching lines added to `manual-checklist.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)