### PR TITLE
Whitespace indicators for tabs and spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to Moped. Versions follow the app's marketing version.
 
+## Unreleased
+
+### Added
+
+- **Show whitespace.** *Settings ▸ Editing ▸ Show whitespace* marks a middle dot for every
+  space and a chevron for every tab, anywhere in the line — so a file that mixes the two
+  gives itself away. Off by default, and display only: nothing is written to your file.
+
 ## 3.0.0
 
 Moped's editor is now its own code. The syntax highlighting, line numbering, indentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to Moped. Versions follow the app's marketing version.
 
-## Unreleased
+## 3.0.1
 
 ### Added
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -177,6 +177,18 @@ Zoom is per window and temporary; it does not change your saved preference.
 the window. Turn it off and long lines run off the edge, with a horizontal scroll bar to
 follow them. Wrapping is a display choice only — no line breaks are ever added to your file.
 
+### Whitespace
+
+*Settings ▸ Editing ▸ Show whitespace* (off by default) marks the whitespace in the
+document: a middle dot `·` for every space and a chevron `»` for every tab. Both are marked
+anywhere they appear, not only in the indentation — a run of spaces inside a comment or
+between words is marked too, which is what makes a file that mixes tabs and spaces obvious
+at a glance. Line endings are not marked.
+
+The markers are drawn in the theme's own text colour, faded well back so they read as
+chrome rather than competing with the code. Like wrapping, this is display only: nothing is
+added to your file, and turning it on does not mark the document as edited.
+
 ---
 
 ## Finding and navigating
@@ -449,6 +461,7 @@ Open with **Moped ▸ Settings…** (⌘,). The window has four sections.
 | Syntax language | Any of the 35 supported languages | plaintext |
 | Wrap long lines | Checkbox | On |
 | Show line numbers | Checkbox | On |
+| Show whitespace | Checkbox | Off |
 | Indentation | Tab · 2 Spaces · 4 Spaces | Tab |
 
 ### Advanced
@@ -589,8 +602,8 @@ Paper size, orientation and scale can be changed in the print panel and the text
 again to match. Margins stay at one inch. Your printer and paper choice carry over to the
 next document you print.
 
-The printed page is the text and nothing else: no headers, no footers, no line numbers, and
-no syntax coloring.
+The printed page is the text and nothing else: no headers, no footers, no line numbers, no
+whitespace markers, and no syntax coloring.
 
 ---
 

--- a/Moped.xcodeproj/project.pbxproj
+++ b/Moped.xcodeproj/project.pbxproj
@@ -414,7 +414,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 40;
+				CURRENT_PROJECT_VERSION = 41;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -427,7 +427,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 3.0.0;
+				MARKETING_VERSION = 3.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = net.machorro.roberto.Moped;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "$(SRCROOT)/Moped/Moped-Bridging-Header.h";
@@ -448,7 +448,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 40;
+				CURRENT_PROJECT_VERSION = 41;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -461,7 +461,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 3.0.0;
+				MARKETING_VERSION = 3.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = net.machorro.roberto.Moped;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "$(SRCROOT)/Moped/Moped-Bridging-Header.h";

--- a/Moped/EditorState.swift
+++ b/Moped/EditorState.swift
@@ -111,6 +111,7 @@ final class EditorState: NSObject, ObservableObject {
 			textView.isHighlightingEnabled = !model.isLargeFile
 			textView.wrapsLines = preferences.doLineWrap
 			textView.showsLineNumberGutter = preferences.doShowLineNumberRuler
+			textView.showsWhitespaceMarkers = preferences.doShowWhitespaceMarkers
 			textView.setPlainText(model.content)
 			applyLanguageToEditor(activeLanguage, on: textView)
 
@@ -171,6 +172,7 @@ final class EditorState: NSObject, ObservableObject {
 		textView.defaultIndentation = preferences.selectedDefaultIndentation.editorIndentation
 		textView.wrapsLines = preferences.doLineWrap
 		textView.showsLineNumberGutter = preferences.doShowLineNumberRuler
+		textView.showsWhitespaceMarkers = preferences.doShowWhitespaceMarkers
 	}
 
 	private func preferredFont(at size: CGFloat) -> NSFont {

--- a/Moped/Localizable.xcstrings
+++ b/Moped/Localizable.xcstrings
@@ -7327,6 +7327,90 @@
         }
       }
     },
+    "pref.whitespace.title" : {
+      "comment" : "Checkbox that draws a dot for each space and a chevron for each tab.",
+      "extractionState" : "stale",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Leerzeichen anzeigen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show whitespace"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar espacios en blanco"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Näytä tyhjemerkit"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher les espaces"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "הצג תווי רווח"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "रिक्त स्थान दिखाएँ"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostra gli spazi"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "空白文字を表示"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toon witruimte"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar espaços em branco"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar espaços em branco"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показувати пробіли"
+          }
+        }
+      }
+    },
     "pref.word_wrap.title" : {
       "extractionState" : "stale",
       "localizations" : {

--- a/Moped/Preferences.swift
+++ b/Moped/Preferences.swift
@@ -189,6 +189,15 @@ final class Preferences: NSObject, ObservableObject, @unchecked Sendable {
 		}
 	}
 
+	@objc dynamic var showWhitespaceMarkers: String {
+		get {
+			getStringValue(forKey: "showWhitespaceMarkers", otherwiseUse: "No")
+		}
+		set {
+			setStringValue(forKey: "showWhitespaceMarkers", to: newValue)
+		}
+	}
+
 	@objc dynamic var launchBehavior: String {
 		get {
 			getStringValue(forKey: "launchBehavior", otherwiseUse: "FileOpenDialog")
@@ -253,6 +262,10 @@ final class Preferences: NSObject, ObservableObject, @unchecked Sendable {
 
 	var doShowLineNumberRuler: Bool {
 		return showLineNumberRuler == "Yes"
+	}
+
+	var doShowWhitespaceMarkers: Bool {
+		return showWhitespaceMarkers == "Yes"
 	}
 
 	var showsMonospacedFontsOnly: Bool {

--- a/Moped/PreferencesView.swift
+++ b/Moped/PreferencesView.swift
@@ -238,6 +238,10 @@ struct PreferencesView: View {
 				checkbox("pref.line_numbers.title", yesNo(\.showLineNumberRuler))
 			}
 			GridRow {
+				emptyLabel
+				checkbox("pref.whitespace.title", yesNo(\.showWhitespaceMarkers))
+			}
+			GridRow {
 				label("pref.default_indentation.title")
 				picker(binding(\.defaultIndentation), options: defaultIndentationOptions, titled: "pref.default_indentation.title")
 			}

--- a/MopedEditor/Sources/MopedEditor/MopedTextView.swift
+++ b/MopedEditor/Sources/MopedEditor/MopedTextView.swift
@@ -33,8 +33,14 @@ public enum EditorIndentation: Sendable {
 /// it needs is set through its own properties — it knows nothing about the app.
 public final class MopedTextView: NSTextView {
 	private let highlighter: SyntaxHighlighter
+	private let whitespaceLayoutManager: WhitespaceLayoutManager
 	private var lineNumberRuler: LineNumberRulerView?
 	var cachedIndentStyle: IndentStyle?
+
+	/// How far back the whitespace markers are faded from the palette's own foreground.
+	/// The same 30% the gutter separator uses — markers have to read as chrome, not as
+	/// text, in every theme and in both appearances.
+	private static let markerAlpha: CGFloat = 0.3
 
 	/// Band painted behind the caret's line on the last draw, so a caret move can
 	/// invalidate just the line it left. See `MopedTextView+CurrentLine`.
@@ -94,6 +100,12 @@ public final class MopedTextView: NSTextView {
 		didSet { applyContainerSizing() }
 	}
 
+	/// Draws `·` for every space and `»` for every tab, anywhere in the line — not only
+	/// in the indentation. Line endings are not marked.
+	public var showsWhitespaceMarkers: Bool = false {
+		didSet { applyWhitespaceMarkers() }
+	}
+
 	/// The editor font. Applied to existing text, typing attributes, and the gutter.
 	public var editorFont: NSFont {
 		didSet { applyFont() }
@@ -142,8 +154,15 @@ public final class MopedTextView: NSTextView {
 
 		// Explicit TextKit 1 stack: temporary attributes (used for token colors) and
 		// the NSRulerView gutter both depend on NSLayoutManager.
+		//
+		// Seeded from the unresolved theme so the very first paint is never a stock system
+		// color; `scrollableEditor` calls `refreshResolvedTheme()` right after, which is
+		// what settles it for a paired theme.
 		let textStorage = NSTextStorage()
-		let layoutManager = NSLayoutManager()
+		let layoutManager = WhitespaceLayoutManager(
+			font: font, color: theme.foreground.withAlphaComponent(Self.markerAlpha)
+		)
+		self.whitespaceLayoutManager = layoutManager
 		let textContainer = NSTextContainer(size: CGSize(width: 0, height: CGFloat.greatestFiniteMagnitude))
 		textStorage.addLayoutManager(layoutManager)
 		layoutManager.addTextContainer(textContainer)
@@ -265,6 +284,7 @@ public final class MopedTextView: NSTextView {
 			range: NSRange(location: 0, length: textStorage?.length ?? 0)
 		)
 		lineNumberRuler?.theme = resolvedTheme
+		whitespaceLayoutManager.markerColor = resolvedTheme.foreground.withAlphaComponent(Self.markerAlpha)
 		needsDisplay = true
 	}
 
@@ -278,6 +298,14 @@ public final class MopedTextView: NSTextView {
 		}
 		lineNumberRuler?.numberFont = Self.gutterFont(matching: editorFont)
 		lineNumberRuler?.invalidateLineNumbers()
+		whitespaceLayoutManager.markerFont = editorFont
+	}
+
+	private func applyWhitespaceMarkers() {
+		whitespaceLayoutManager.showsWhitespaceMarkers = showsWhitespaceMarkers
+		// Every visible line changes at once, so unlike the caret band there is no smaller
+		// region worth invalidating.
+		needsDisplay = true
 	}
 
 	private func baseAttributes() -> [NSAttributedString.Key: Any] {

--- a/MopedEditor/Sources/MopedEditor/WhitespaceLayoutManager.swift
+++ b/MopedEditor/Sources/MopedEditor/WhitespaceLayoutManager.swift
@@ -1,0 +1,178 @@
+//
+//  WhitespaceLayoutManager.swift
+//
+//  MopedEditor - The homegrown text editor core and syntax highlighter used by Moped.
+//  Copyright © 2019-2026 Roberto Machorro. All rights reserved.
+//
+//	This program is free software: you can redistribute it and/or modify
+//	it under the terms of the GNU General Public License as published by
+//	the Free Software Foundation, either version 3 of the License, or
+//	(at your option) any later version.
+//
+//	This program is distributed in the hope that it will be useful,
+//	but WITHOUT ANY WARRANTY; without even the implied warranty of
+//	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//	GNU General Public License for more details.
+//
+//	You should have received a copy of the GNU General Public License
+//	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import AppKit
+
+/// One whitespace marker to paint, in text container coordinates.
+struct WhitespaceMarker: Equatable {
+	enum Kind {
+		case space
+		case tab
+	}
+
+	let kind: Kind
+
+	/// Top-left of the marker's own line box — the point `NSAttributedString.draw(at:)`
+	/// takes in the editor's flipped coordinates.
+	let origin: NSPoint
+}
+
+/// The editor's layout manager. On top of the text it has just painted it draws
+/// whitespace markers — `·` for every space, `»` for every tab — when the setting is on.
+///
+/// A layout manager subclass rather than a `draw(_:)` override on the text view: the
+/// glyph range and the container origin both arrive as parameters, so markers land
+/// wherever TextKit actually put the glyphs, on every path that repaints, with no second
+/// invalidation story to keep in sync. It also avoids the gutter's `ensureLayout` dance —
+/// anything being drawn is by definition already laid out.
+final class WhitespaceLayoutManager: NSLayoutManager {
+	private static let spaceSymbol = "·"
+	private static let tabSymbol = "»"
+
+	var showsWhitespaceMarkers = false
+
+	/// Pushed in from `MopedTextView.applyTheme()`: the layout manager cannot see
+	/// `resolvedTheme` and has no way to ask for it.
+	var markerColor: NSColor {
+		didSet { rebuildMarkers() }
+	}
+
+	var markerFont: NSFont {
+		didSet { rebuildMarkers() }
+	}
+
+	private var spaceMarker = NSAttributedString()
+	private var tabMarker = NSAttributedString()
+
+	/// Half the difference between a space's advance and the dot's, so the dot sits in the
+	/// middle of the cell it stands for rather than against its left edge. Zero for a
+	/// monospaced face; it earns its keep for the proportional fonts the picker still
+	/// offers.
+	private var spaceMarkerInset: CGFloat = 0
+
+	init(font: NSFont, color: NSColor) {
+		self.markerFont = font
+		self.markerColor = color
+		super.init()
+		rebuildMarkers()
+	}
+
+	@available(*, unavailable)
+	required init?(coder: NSCoder) {
+		fatalError("init(coder:) has not been implemented")
+	}
+
+	override func drawGlyphs(forGlyphRange glyphsToShow: NSRange, at origin: NSPoint) {
+		super.drawGlyphs(forGlyphRange: glyphsToShow, at: origin)
+		guard showsWhitespaceMarkers else {
+			return
+		}
+		// After `super`, never before: selection and find-bar highlights are painted in
+		// `drawBackground(forGlyphRange:at:)`, so drawing here is what keeps markers
+		// visible inside a selection rather than buried under it.
+		for marker in whitespaceMarkers(forGlyphRange: glyphsToShow) {
+			let symbol = marker.kind == .space ? spaceMarker : tabMarker
+			symbol.draw(at: NSPoint(x: marker.origin.x + origin.x, y: marker.origin.y + origin.y))
+		}
+	}
+
+	/// Markers to paint for `glyphRange`, in glyph order.
+	///
+	/// Split out of `drawGlyphs` for the reason `LineNumberRulerView.visibleLineNumbers(for:)`
+	/// was split out of the gutter's draw: geometry only ever exercised inside a graphics
+	/// context is geometry nothing can assert on.
+	func whitespaceMarkers(forGlyphRange glyphRange: NSRange) -> [WhitespaceMarker] {
+		guard glyphRange.length > 0, let content = textStorage?.string as NSString? else {
+			return []
+		}
+		let textRange = characterRange(forGlyphRange: glyphRange, actualGlyphRange: nil)
+		guard textRange.length > 0 else {
+			return []
+		}
+		var characters = [unichar](repeating: 0, count: textRange.length)
+		content.getCharacters(&characters, range: textRange)
+
+		let baseline = defaultBaselineOffset(for: markerFont)
+		var markers: [WhitespaceMarker] = []
+		var fragment = NSRect.zero
+		var fragmentGlyphs = NSRange(location: NSNotFound, length: 0)
+
+		for offset in 0..<characters.count {
+			guard let kind = Self.markerKind(for: characters[offset]) else {
+				continue
+			}
+			let glyphIndex = glyphIndexForCharacter(at: textRange.location + offset)
+			guard NSLocationInRange(glyphIndex, glyphRange) else {
+				continue
+			}
+			// One fragment lookup per line rather than one per marker: an indented line is
+			// a run of adjacent spaces that all share a fragment. `withoutAdditionalLayout`
+			// because this runs inside a draw, where forcing layout re-enters TextKit.
+			if !NSLocationInRange(glyphIndex, fragmentGlyphs) {
+				fragment = lineFragmentRect(
+					forGlyphAt: glyphIndex,
+					effectiveRange: &fragmentGlyphs,
+					withoutAdditionalLayout: true
+				)
+			}
+			// `location(forGlyphAt:)` is relative to the fragment, and its `y` is the
+			// baseline. Expressing everything against the fragment the glyph is actually in
+			// is what makes a wrapped line need no special case.
+			let position = location(forGlyphAt: glyphIndex)
+			let inset = kind == .space ? spaceMarkerInset : 0
+			markers.append(
+				WhitespaceMarker(
+					kind: kind,
+					origin: NSPoint(
+						x: fragment.minX + position.x + inset,
+						y: fragment.minY + position.y - baseline
+					)
+				)
+			)
+		}
+		return markers
+	}
+
+	/// A tab's marker sits at the **leading edge** of its advance, not centred in it:
+	/// the advance runs to the next tab stop, so a centred chevron would slide sideways
+	/// whenever text ahead of it changed, which reads as a rendering bug.
+	private static func markerKind(for character: unichar) -> WhitespaceMarker.Kind? {
+		switch character {
+		case 0x20:
+			return .space
+		case 0x09:
+			return .tab
+		default:
+			return nil
+		}
+	}
+
+	private func rebuildMarkers() {
+		let attributes: [NSAttributedString.Key: Any] = [.font: markerFont, .foregroundColor: markerColor]
+		spaceMarker = NSAttributedString(string: Self.spaceSymbol, attributes: attributes)
+		tabMarker = NSAttributedString(string: Self.tabSymbol, attributes: attributes)
+
+		// Measured off the attributed string rather than off the font's own metrics, so
+		// the centring stays right when the editor font has no `·` and AppKit substitutes
+		// a face that does.
+		let spaceWidth = (" " as NSString).size(withAttributes: [.font: markerFont]).width
+		spaceMarkerInset = (spaceWidth - spaceMarker.size().width) / 2.0
+	}
+}

--- a/MopedEditor/Tests/MopedEditorTests/EditingIntegrationTests.swift
+++ b/MopedEditor/Tests/MopedEditorTests/EditingIntegrationTests.swift
@@ -248,6 +248,22 @@ final class EditingIntegrationTests: EditorTestCase {
 		XCTAssertFalse(scrollView.rulersVisible)
 	}
 
+	/// The flag the draw path actually reads lives on the layout manager, not on the text
+	/// view, so a setter that forgot to push it down would leave the setting inert.
+	func testWhitespaceMarkerToggle() throws {
+		let (_, textView) = makeEditor()
+		let layoutManager = try XCTUnwrap(textView.layoutManager as? WhitespaceLayoutManager)
+
+		XCTAssertFalse(textView.showsWhitespaceMarkers, "whitespace markers are off by default")
+		XCTAssertFalse(layoutManager.showsWhitespaceMarkers)
+
+		textView.showsWhitespaceMarkers = true
+		XCTAssertTrue(layoutManager.showsWhitespaceMarkers, "the toggle has to reach the layout manager")
+
+		textView.showsWhitespaceMarkers = false
+		XCTAssertFalse(layoutManager.showsWhitespaceMarkers)
+	}
+
 	/// The gutter splices its offset array from the storage notification rather than
 	/// rebuilding it. These go through the real editor so a mistake in the wiring — a
 	/// missed notification, a stale array — shows up as a wrong line count.

--- a/MopedEditor/Tests/MopedEditorTests/WhitespaceMarkerTests.swift
+++ b/MopedEditor/Tests/MopedEditorTests/WhitespaceMarkerTests.swift
@@ -1,0 +1,227 @@
+//
+//  WhitespaceMarkerTests.swift
+//
+//  MopedEditor - The homegrown text editor core and syntax highlighter used by Moped.
+//  Copyright © 2019-2026 Roberto Machorro. All rights reserved.
+//
+//	This program is free software: you can redistribute it and/or modify
+//	it under the terms of the GNU General Public License as published by
+//	the Free Software Foundation, either version 3 of the License, or
+//	(at your option) any later version.
+//
+//	This program is distributed in the hope that it will be useful,
+//	but WITHOUT ANY WARRANTY; without even the implied warranty of
+//	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//	GNU General Public License for more details.
+//
+//	You should have received a copy of the GNU General Public License
+//	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import XCTest
+@testable import MopedEditor
+
+/// The whitespace markers are pure paint, so nothing about them can be observed through
+/// the text or its attributes. These go through `whitespaceMarkers(forGlyphRange:)`, the
+/// list the draw loop iterates — the same seam `visibleLineNumbers(for:)` opened for the
+/// gutter.
+final class WhitespaceMarkerTests: EditorTestCase {
+	private func manager(of textView: MopedTextView) throws -> WhitespaceLayoutManager {
+		try XCTUnwrap(textView.layoutManager as? WhitespaceLayoutManager)
+	}
+
+	/// `whitespaceMarkers` reads geometry without forcing layout, because in the app it
+	/// only ever runs inside a draw. Outside one, layout has to be forced first or every
+	/// rect comes back zero.
+	private func markers(in textView: MopedTextView) throws -> [WhitespaceMarker] {
+		let layoutManager = try manager(of: textView)
+		let textContainer = try XCTUnwrap(textView.textContainer)
+		layoutManager.ensureLayout(for: textContainer)
+		return layoutManager.whitespaceMarkers(
+			forGlyphRange: layoutManager.glyphRange(for: textContainer)
+		)
+	}
+
+	/// Pins the "every space and tab, not just the indentation" decision: a marker for the
+	/// spaces between words and inside the comment too, and none for anything else.
+	func testEverySpaceAndTabGetsAMarker() throws {
+		let (_, textView) = makeEditor()
+		let content = "\tlet a = 1 // two words\n  b = 2\n"
+		textView.showsWhitespaceMarkers = true
+		textView.setPlainText(content)
+
+		let expected: [WhitespaceMarker.Kind] = content.compactMap {
+			switch $0 {
+			case " ": return .space
+			case "\t": return .tab
+			default: return nil
+			}
+		}
+		let produced = try markers(in: textView).map(\.kind)
+
+		XCTAssertEqual(
+			produced, expected,
+			"every space and tab in the document should get exactly one marker, in order, "
+				+ "and nothing else should get one"
+		)
+	}
+
+	/// The markers are display-only. Nothing may reach the text, or toggling the setting
+	/// would dirty the document and land on the undo stack.
+	func testMarkersDoNotTouchTheText() throws {
+		let (_, textView) = makeEditor()
+		textView.setPlainText("\ta = 1\n")
+		textView.showsWhitespaceMarkers = true
+
+		XCTAssertEqual(textView.string, "\ta = 1\n", "drawing markers must not rewrite the text")
+		XCTAssertFalse(try markers(in: textView).isEmpty, "the markers should still be produced")
+	}
+
+	/// A tab's advance runs to the next tab stop, so a chevron centred in it would slide
+	/// sideways whenever text ahead of it changed. It belongs at the leading edge.
+	func testTabMarkerSitsAtTheLeadingEdgeOfItsAdvance() throws {
+		let (_, textView) = makeEditor()
+		textView.showsWhitespaceMarkers = true
+		textView.setPlainText("a\tb")
+
+		let layoutManager = try manager(of: textView)
+		let textContainer = try XCTUnwrap(textView.textContainer)
+		layoutManager.ensureLayout(for: textContainer)
+
+		let tabMarker = try XCTUnwrap(try markers(in: textView).first { $0.kind == .tab })
+		let fragment = layoutManager.lineFragmentRect(forGlyphAt: 1, effectiveRange: nil)
+		let tabStart = fragment.minX + layoutManager.location(forGlyphAt: 1).x
+		let nextCharacter = fragment.minX + layoutManager.location(forGlyphAt: 2).x
+
+		XCTAssertEqual(
+			tabMarker.origin.x, tabStart, accuracy: 0.5,
+			"the chevron belongs where the tab's advance starts, not at the tab stop it runs to"
+		)
+		XCTAssertLessThan(
+			tabMarker.origin.x, nextCharacter,
+			"the chevron must sit inside the tab's own advance, ahead of the character after it"
+		)
+	}
+
+	/// Markers are placed against the fragment the glyph is actually in, which is the whole
+	/// reason a wrapped line needs no special case. If they were placed against the line
+	/// they would all pile onto one row.
+	func testWrappedLineMarksEveryVisualRow() throws {
+		let (_, textView) = makeEditor()
+		textView.wrapsLines = true
+		textView.showsWhitespaceMarkers = true
+		textView.setPlainText(String(repeating: "word ", count: 200))
+
+		let rows = Set(try markers(in: textView).map { $0.origin.y.rounded() })
+
+		XCTAssertGreaterThan(
+			rows.count, 1,
+			"a line wrapped across the 600pt test viewport should place markers on every "
+				+ "visual row it occupies, not all on the first"
+		)
+	}
+
+	/// Doubling the font size has to move the markers with the glyphs they annotate,
+	/// because the whole placement is derived from live layout rather than from constants.
+	///
+	/// Measured as the gap between two markers on one line rather than as an absolute x:
+	/// an absolute x also carries the text container's line-fragment padding, which is a
+	/// fixed 5pt and quite rightly does not scale with the font.
+	func testMarkersScaleWithTheEditorFont() throws {
+		let (_, textView) = makeEditor()
+		textView.showsWhitespaceMarkers = true
+		textView.setPlainText("a b c\nd e f\n")
+
+		let small = try markers(in: textView)
+		textView.editorFont = NSFontManager.shared.convert(
+			textView.editorFont, toSize: textView.editorFont.pointSize * 2
+		)
+		let large = try markers(in: textView)
+
+		XCTAssertEqual(small.count, 4, "two spaces on each of the two lines")
+		XCTAssertEqual(large.count, small.count, "a font change cannot change how many markers there are")
+
+		let smallGap = small[1].origin.x - small[0].origin.x
+		let largeGap = large[1].origin.x - large[0].origin.x
+		XCTAssertEqual(
+			largeGap, smallGap * 2, accuracy: 0.5,
+			"two markers a fixed number of characters apart should separate by twice as much "
+				+ "at twice the font size"
+		)
+
+		let smallSecondLine = try XCTUnwrap(small.last)
+		let largeSecondLine = try XCTUnwrap(large.last)
+		XCTAssertGreaterThan(
+			largeSecondLine.origin.y, smallSecondLine.origin.y,
+			"the second line sits lower once the lines are twice as tall"
+		)
+	}
+
+	/// The seam tests all stop at the list of markers. This is the only one that proves the
+	/// draw override paints them: it renders the view and looks at the pixels where a space
+	/// is, which stay pure background until markers are turned on.
+	func testSpacesArePaintedIntoTheView() throws {
+		let (scrollView, textView) = makeEditor(theme: .defaultLightPalette)
+		let window = NSWindow(
+			contentRect: scrollView.frame, styleMask: [.titled],
+			backing: .buffered, defer: false
+		)
+		window.contentView = scrollView
+		textView.setPlainText("a b\n")
+		drainHighlightPasses()
+
+		// Locate the cell from the marker's own geometry rather than guessing at
+		// coordinates: `origin` is in container space, the view is inset by
+		// `textContainerInset`, and a marker is about one line tall.
+		let marker = try XCTUnwrap(try markers(in: textView).first)
+		let cell = NSRect(
+			x: marker.origin.x + textView.textContainerInset.width,
+			y: marker.origin.y + textView.textContainerInset.height,
+			width: try XCTUnwrap(textView.layoutManager?.defaultLineHeight(for: textView.editorFont)),
+			height: try XCTUnwrap(textView.layoutManager?.defaultLineHeight(for: textView.editorFont))
+		)
+
+		// Compared against the same region drawn without markers rather than against the
+		// theme's background: the caret-line band already tints the whole first line, so
+		// "differs from the background" would be true either way. Nothing but the setting
+		// changes between the two renders, so any difference is the marker.
+		let blank = try render(textView, in: cell)
+		textView.showsWhitespaceMarkers = true
+		let marked = try render(textView, in: cell)
+
+		XCTAssertNotEqual(
+			blank, marked,
+			"turning markers on has to actually paint a dot where the space is"
+		)
+	}
+
+	private func render(_ textView: MopedTextView, in rect: NSRect) throws -> Data {
+		let rep = try XCTUnwrap(textView.bitmapImageRepForCachingDisplay(in: rect))
+		textView.cacheDisplay(in: rect, to: rep)
+		return try XCTUnwrap(rep.tiffRepresentation)
+	}
+
+	/// The layout manager cannot see `resolvedTheme`, so the color has to be pushed in from
+	/// `applyTheme()`. That is also the funnel a light/dark flip goes through, and a marker
+	/// left on the light palette's color would be invisible on a dark background.
+	func testMarkerColorFollowsTheThemeAndTheAppearance() throws {
+		let (_, textView) = makeEditor(theme: .turboPalette)
+		let layoutManager = try manager(of: textView)
+
+		XCTAssertEqual(
+			layoutManager.markerColor,
+			textView.resolvedTheme.foreground.withAlphaComponent(0.3),
+			"markers are drawn from the palette's own foreground, faded back to chrome"
+		)
+
+		textView.theme = MopedTheme.defaultLightPalette.paired(withDark: .defaultDarkPalette)
+		textView.appearance = NSAppearance(named: .darkAqua)
+		textView.viewDidChangeEffectiveAppearance()
+
+		XCTAssertEqual(
+			layoutManager.markerColor,
+			textView.resolvedTheme.foreground.withAlphaComponent(0.3),
+			"flipping to dark has to re-tint the markers along with the rest of the palette"
+		)
+	}
+}

--- a/manual-checklist.md
+++ b/manual-checklist.md
@@ -28,6 +28,9 @@
 - [ ] Settings in a non‑English locale (German is the longest) — no label truncation and the control column stays aligned.
 - [ ] "Show only monospaced fonts" — checking it shrinks the font list to fixed‑pitch faces; with a proportional font already selected (e.g. Helvetica) the picker still shows it rather than going blank, and the stored font is not rewritten.
 - [ ] Wrap long lines / Show line numbers are checkboxes, not Yes/No pickers, and still drive the editor.
+- [ ] Show whitespace is off on a fresh install, and the Editing pane still fits the window without a scroller (check German and pt‑BR, the widest locales).
+- [ ] Show whitespace on, with a file that mixes tabs and spaces mid‑line — a `·` in every space and one `»` at the start of every tab's advance, including inside comments and string literals, and nothing at all on line endings. It reaches the already‑open document without reopening it.
+- [ ] Whitespace markers stay visible inside a selection, on the caret line, and under a find‑bar match; they survive a theme switch and a Light/Dark flip (Turbo is the contrast stress case); they scale with ⌘+/⌘−; a wrapped line marks whitespace on every visual row; scrolling a large file with them on stays smooth; printing shows none.
 - [ ] Advanced → Manage… renders as a button (not a popup) and opens Default File Associations.
 - [ ] Cmd‑+, Cmd‑−, Cmd‑0 — increase/decrease/reset font size.
 - [ ] Tab key with no selection: hard‑tab file inserts \t; 2‑space file inserts 2 spaces aligned to column.


### PR DESCRIPTION
Adds **Settings ▸ Editing ▸ Show whitespace**, off by default: a middle dot for every space, a chevron for every tab, marked anywhere they appear rather than only in the leading run. Line endings are deliberately not marked. Closes the one item in `TODO.md`.

## How it draws

A small `NSLayoutManager` subclass, `WhitespaceLayoutManager`, overrides `drawGlyphs(forGlyphRange:at:)` — calls `super`, then paints the markers. AppKit hands it the exact glyph range and the container origin, so there is no visible-range query and none of the `ensureLayout` trouble `allowsNonContiguousLayout` caused the gutter. Every path that repaints text carries the markers with it (scroll, edit, wrap toggle, theme change), with no invalidation code of its own. Drawing after `super` is what keeps markers on top of the selection and find-bar highlights instead of buried under them.

Nothing is written to the text storage and no attribute is touched, so `SyntaxHighlighter`'s ownership of the `.foregroundColor` temporary attributes is undisturbed, and toggling the setting cannot dirty the document or land on the undo stack.

Markers take the palette's own foreground faded to 30% — the same proportion the gutter separator uses — so no theme and no `.mopedtheme` file needed a new colour. `applyTheme()` pushes it, which means a theme switch and a light/dark flip both reach the markers for free.

Placement is derived from live layout, never from constants: each marker is positioned against the line fragment its glyph is actually in, so a wrapped line needs no special case and any font size lands correctly. The chevron sits at the leading edge of a tab's advance rather than centred in it — the advance runs to the next tab stop, so a centred chevron would slide sideways whenever text ahead of it changed.

## Verification

All three CI gates:

- `swiftlint --strict` — 0 violations in 94 files
- `swift test --package-path MopedEditor` — 222 tests, none failing or skipped
- `./scripts/check_localized_strings.sh` — passing

Seven new tests cover placement, the tab's leading edge, wrapped lines, font scaling, theme and dark-mode re-tinting, and one that renders the view and proves the pixels change. The editor was also rendered offscreen with mixed tab- and space-indented Swift and compared against Xcode's own rendering.

`pref.whitespace.title` is translated into all 13 locales, keeping the catalog at 100% coverage. Release build verified at 3.0.1 (41).

## Not covered

Printing goes through `SourcePrintView`'s separate CTFramesetter path, so markers do not print — `DOCUMENTATION.md` now says so explicitly. The settings window keeps its measured `590×246` frame; the Editing pane goes from four rows to five but trades a bordered button for a shorter checkbox, and it sits in a `ScrollView`. That is on the manual checklist for German and pt-BR rather than pre-emptively resized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)